### PR TITLE
Fix: handle empty Discogs responses in master release lookup

### DIFF
--- a/vinyl_sorter/discogs_api.py
+++ b/vinyl_sorter/discogs_api.py
@@ -107,14 +107,20 @@ class DiscogsAPI:
     # -- Release / Master -----------------------------------------------------
 
     def lookup_master_fields(self, release_id: int) -> Tuple[bool, str, int]:
-        """Return (master_exists, master_title, master_year) for a release."""
-        release_info = self._client.release(release_id)
+        """Return (master_exists, master_title, master_year) for a release.
 
-        if release_info.master:
-            title = release_info.master.title
-            year = release_info.master.year
-            logger.debug("Found master '%s' dated %s", title, year)
-            return True, title, year
+        Returns (False, "Unknown", -1) if the release or master cannot
+        be fetched (e.g. empty API response, network errors).
+        """
+        try:
+            release_info = self._client.release(release_id)
+            if release_info.master:
+                title = release_info.master.title
+                year = release_info.master.year
+                logger.debug("Found master '%s' dated %s", title, year)
+                return True, title, year
+        except Exception as exc:
+            logger.warning("Could not look up master for release %d: %s", release_id, exc)
 
         return False, "Unknown", -1
 


### PR DESCRIPTION
## Problem
Some Discogs releases return empty responses when fetching master release info, causing a `JSONDecodeError` in the Discogs client library. Same class of issue as the artist 404 from PR #1.

## Fix
Wrapped `lookup_master_fields` in a try/except. When the master lookup fails, it logs a warning and falls back to `(False, "Unknown", -1)` — meaning the record just uses its own release year for sorting instead of the master year.

## Impact
No change to sorting logic for records that work correctly. Records with broken master lookups now sort by their release year instead of crashing the entire run.