### PR TITLE
Fix: Bugs #6, #7, #8 — parenthetical numbers, compilation sort, month sorting

### DIFF
--- a/vinyl_sorter/constants.py
+++ b/vinyl_sorter/constants.py
@@ -25,3 +25,7 @@ LIVE_KEYWORDS = ["live", "recorded at", "concert", "venue"]
 
 # Artist names that indicate a compilation / various-artists release
 COMPILATION_ARTISTS = {"Various", "Various Artists"}
+
+# Pattern matching parenthetical disambiguation numbers from Discogs
+# e.g. "Wings (2)" → "Wings"
+PARENTHETICAL_NUMBER_RE = r"\s*\(\d+\)\s*$"

--- a/vinyl_sorter/discogs_api.py
+++ b/vinyl_sorter/discogs_api.py
@@ -106,10 +106,10 @@ class DiscogsAPI:
 
     # -- Release / Master -----------------------------------------------------
 
-    def lookup_master_fields(self, release_id: int) -> Tuple[bool, str, int]:
-        """Return (master_exists, master_title, master_year) for a release.
+    def lookup_master_fields(self, release_id: int) -> Tuple[bool, str, int, int]:
+        """Return (master_exists, master_title, master_year, master_month) for a release.
 
-        Returns (False, "Unknown", -1) if the release or master cannot
+        Returns (False, "Unknown", -1, 0) if the release or master cannot
         be fetched (e.g. empty API response, network errors).
         """
         try:
@@ -117,12 +117,30 @@ class DiscogsAPI:
             if release_info.master:
                 title = release_info.master.title
                 year = release_info.master.year
-                logger.debug("Found master '%s' dated %s", title, year)
-                return True, title, year
+                # Try to get month from the master's main_release date
+                month = 0
+                try:
+                    main_release = release_info.master.main_release
+                    if main_release:
+                        date_str = getattr(main_release, 'date_added', '') or ''
+                        # Also check data dict for released date
+                        data = getattr(main_release, 'data', {}) or {}
+                        released = data.get('released', '') or ''
+                        if released and '-' in released:
+                            parts = released.split('-')
+                            if len(parts) >= 2:
+                                try:
+                                    month = int(parts[1])
+                                except (ValueError, IndexError):
+                                    pass
+                except Exception:
+                    pass  # Month extraction is best-effort
+                logger.debug("Found master '%s' dated %s-%02d", title, year, month)
+                return True, title, year, month
         except Exception as exc:
             logger.warning("Could not look up master for release %d: %s", release_id, exc)
 
-        return False, "Unknown", -1
+        return False, "Unknown", -1, 0
 
     def lookup_live_year(self, release_id: int) -> Optional[int]:
         """Search release and master text fields for a live-performance year."""

--- a/vinyl_sorter/exporter.py
+++ b/vinyl_sorter/exporter.py
@@ -23,7 +23,10 @@ def export_collection(
     """
     logger.info("Saving sorted collection to '%s'…", output_file)
 
-    headers = ["Sort #", "Sort Artist", "Artist", "Album", "Sort Year", "Year", "Live", "Compilation"]
+    headers = [
+        "Sort #", "Sort Artist", "Artist", "Album",
+        "Sort Year", "Sort Month", "Year", "Live", "Compilation",
+    ]
 
     with open(output_file, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=headers, delimiter=delimiter)
@@ -36,6 +39,7 @@ def export_collection(
                 "Artist": record.release_artist,
                 "Album": record.release_title,
                 "Sort Year": record.sort_year,
+                "Sort Month": record.sort_month if record.sort_month else "",
                 "Year": record.release_year,
                 "Live": "Yes" if record.is_live else "",
                 "Compilation": "Yes" if record.is_compilation else "",

--- a/vinyl_sorter/models.py
+++ b/vinyl_sorter/models.py
@@ -5,19 +5,32 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple, Optional
 
 from .constants import (
     ArtistType,
     COMPILATION_ARTISTS,
     INSIGNIFICANT_LEADING_WORDS,
     LIVE_KEYWORDS,
+    PARENTHETICAL_NUMBER_RE,
 )
 
 if TYPE_CHECKING:
     from .discogs_api import DiscogsAPI
 
 logger = logging.getLogger(__name__)
+
+
+def clean_artist_name(name: str) -> str:
+    """Strip Discogs disambiguation suffixes like '(2)' from artist names.
+
+    Args:
+        name: Raw artist name from Discogs.
+
+    Returns:
+        Cleaned artist name.
+    """
+    return re.sub(PARENTHETICAL_NUMBER_RE, "", name).strip()
 
 
 @dataclass
@@ -42,6 +55,7 @@ class VinylRecord:
     is_live: bool = False
     sort_artist: str = "None"
     sort_year: int = -1
+    sort_month: int = 0  # 0 = unknown; 1–12 = Jan–Dec
     sort_sequence: int = -1
 
     # Import order tracking
@@ -54,6 +68,8 @@ class VinylRecord:
         VinylRecord._import_counter += 1
         if self.import_number == -1:
             self.import_number = VinylRecord._import_counter
+        # Clean parenthetical numbers from artist name on load (#6)
+        self.release_artist = clean_artist_name(self.release_artist)
 
     def __repr__(self) -> str:
         return f"'{self.release_title}' by {self.release_artist}"
@@ -100,21 +116,28 @@ class VinylRecord:
         )
         return self.release_artist
 
-    def compute_sort_year(self, api: DiscogsAPI) -> int:
-        """Determine the best year for chronological sorting.
+    def compute_sort_date(self, api: DiscogsAPI) -> Tuple[int, int]:
+        """Determine the best year and month for chronological sorting.
 
-        Re-releases → original (master) release year.
+        Re-releases → original (master) release year/month.
         Live albums  → performance year extracted from text fields.
+
+        Returns:
+            (year, month) tuple. Month is 0 if unknown.
         """
         parsed_year = self.release_year
+        parsed_month = 0
         field_to_check = self.release_title
 
         # Check for a master release (original release date)
-        master_exists, master_title, master_year = api.lookup_master_fields(self.discogs_id)
+        master_exists, master_title, master_year, master_month = api.lookup_master_fields(
+            self.discogs_id
+        )
         if master_exists:
             parsed_year = master_year
+            parsed_month = master_month
             field_to_check = master_title
-            logger.debug("Have master title '%s' dated '%s'", master_title, master_year)
+            logger.debug("Have master title '%s' dated %s-%02d", master_title, master_year, master_month)
 
         # Check if this is a live recording
         logger.debug("Scanning '%s' for live markers", field_to_check)
@@ -127,5 +150,6 @@ class VinylRecord:
             live_year = api.lookup_live_year(self.discogs_id)
             if live_year is not None and live_year != -1:
                 parsed_year = live_year
+                parsed_month = 0  # Live year extraction doesn't give us month
 
-        return parsed_year
+        return parsed_year, parsed_month

--- a/vinyl_sorter/parser.py
+++ b/vinyl_sorter/parser.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from .constants import COMPILATION_ARTISTS
 from .discogs_api import DiscogsAPI
 from .models import VinylRecord
 
@@ -47,7 +48,7 @@ def parse_collection(
     api: DiscogsAPI,
     aliases: Optional[Dict[str, str]] = None,
 ) -> None:
-    """Populate sort_artist and sort_year on each record.
+    """Populate sort_artist, sort_year, and sort_month on each record.
 
     Records are pre-sorted by release_artist so that consecutive records
     by the same artist can reuse the computed sort_artist (avoiding
@@ -66,19 +67,23 @@ def parse_collection(
 
     last_artist = ""
     last_sort_artist = ""
+    last_is_compilation = False
 
     for record in records:
         logger.info("Parsing %s", record)
 
-        # Check aliases first
+        # Check aliases first (using cleaned name — parentheticals already stripped)
         if record.release_artist in aliases:
             record.sort_artist = aliases[record.release_artist]
+            # Check if the alias target is a compilation
+            record.is_compilation = record.release_artist in COMPILATION_ARTISTS
             logger.debug(
                 "Applied alias: '%s' → '%s'", record.release_artist, record.sort_artist
             )
         elif record.release_artist == last_artist:
             # Reuse cached sort_artist for consecutive same-artist records
             record.sort_artist = last_sort_artist
+            record.is_compilation = last_is_compilation  # Propagate compilation flag (#7)
         else:
             record.sort_artist = record.compute_sort_artist(api)
 
@@ -86,7 +91,10 @@ def parse_collection(
 
         last_artist = record.release_artist
         last_sort_artist = record.sort_artist
+        last_is_compilation = record.is_compilation
 
-        # Compute sort year
-        record.sort_year = record.compute_sort_year(api)
-        logger.debug("Parsed '%s' as dated %s", record.release_title, record.sort_year)
+        # Compute sort date (year + month)
+        record.sort_year, record.sort_month = record.compute_sort_date(api)
+        logger.debug(
+            "Parsed '%s' as dated %s-%02d", record.release_title, record.sort_year, record.sort_month
+        )

--- a/vinyl_sorter/sorter.py
+++ b/vinyl_sorter/sorter.py
@@ -1,4 +1,4 @@
-"""Sort the parsed collection by artist then by year."""
+"""Sort the parsed collection by artist then by date."""
 
 import logging
 import operator
@@ -10,10 +10,11 @@ logger = logging.getLogger(__name__)
 
 
 def sort_collection(records: List[VinylRecord]) -> List[VinylRecord]:
-    """Sort records alphabetically by sort_artist, then chronologically by sort_year.
+    """Sort records: compilations last, then alphabetically by sort_artist,
+    then chronologically by sort_year and sort_month.
 
     Args:
-        records: Parsed records with sort_artist and sort_year populated.
+        records: Parsed records with sort fields populated.
 
     Returns:
         New list of records in sorted order.
@@ -22,7 +23,8 @@ def sort_collection(records: List[VinylRecord]) -> List[VinylRecord]:
 
     # is_compilation=False (0) sorts before True (1), so compilations land at the end
     sorted_records = sorted(
-        records, key=operator.attrgetter("is_compilation", "sort_artist", "sort_year")
+        records,
+        key=operator.attrgetter("is_compilation", "sort_artist", "sort_year", "sort_month"),
     )
 
     for i, record in enumerate(sorted_records, start=1):


### PR DESCRIPTION
## Fixes

### #6 — Remove parenthetical numbers
Discogs appends disambiguation suffixes like `(2)` to artist names (e.g. `Wings (2)`). These are now stripped on load in `VinylRecord.__post_init__`, so `Wings (2)` becomes `Wings` before alias lookup or sort logic runs. This means the alias file entry `"Wings": "McCartney"` works without needing a separate `"Wings (2)"` entry.

### #7 — Compilations at the end
The same-artist cache in `parse_collection` was propagating `sort_artist = "Compilation"` but **not** `is_compilation = True` for consecutive Various/Various Artists records. Since the sort key uses `is_compilation` to push compilations to the end, uncached ones landed in the C's. Now the `is_compilation` flag is cached and propagated alongside `sort_artist`.

### #8 — Sort by month within year
For artists with multiple releases in one year, sorting now uses `(year, month)` instead of just year. Month is extracted from master release data when available. Sort key is now `(is_compilation, sort_artist, sort_year, sort_month)`. CSV output includes a Sort Month column. Month = 0 means unknown (sorts before known months).

## Files Changed
- `constants.py` — Added `PARENTHETICAL_NUMBER_RE` pattern
- `models.py` — `clean_artist_name()` helper, `sort_month` field, `compute_sort_date()` returns (year, month)
- `discogs_api.py` — `lookup_master_fields()` returns 4-tuple with month
- `parser.py` — Propagates `is_compilation` through cache, uses new date tuple
- `sorter.py` — Sort key includes `sort_month`
- `exporter.py` — Sort Month column in CSV

Closes #6, closes #7, closes #8