### PR TITLE
Feat: Persist sort data to Discogs custom fields (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,43 @@ python -m vinyl_sorter --help
 | `--log-file` | `vinyl_sorter.log` | Log file path |
 | `--log-level` | `INFO` | Logging level (DEBUG/INFO/WARNING/ERROR) |
 | `--alias-file` | None | JSON file for artist sort-name overrides |
+| `--force-reparse` | off | Ignore persisted data and recompute everything |
+| `--no-write-back` | off | Don't write computed data back to Discogs |
+| `--field-sort-artist` | `Sort Artist` | Discogs custom field name for sort artist |
+| `--field-sort-year` | `Sort Year` | Discogs custom field name for sort year |
+| `--field-sort-month` | `Sort Month` | Discogs custom field name for sort month |
+
+### First-Time Setup: Discogs Custom Fields
+
+VinylSorter can save computed sort data back to your Discogs account so that subsequent runs are dramatically faster (seconds instead of minutes). This is optional but highly recommended.
+
+**One-time setup (takes 30 seconds):**
+
+1. Go to your [Discogs Collection Settings](https://www.discogs.com/settings/collection)
+2. Under **Collection Notes**, add three new custom fields:
+   - **Sort Artist** — type: Textarea
+   - **Sort Year** — type: Textarea
+   - **Sort Month** — type: Textarea
+3. Save your settings
+
+The field names must match exactly (case-insensitive). VinylSorter auto-detects them by name when it starts up and will tell you what it found:
+
+```
+Custom fields found: sort_artist→4, sort_year→5, sort_month→6
+```
+
+If any fields are missing or misnamed, VinylSorter will warn you and continue without persistence for those fields. Use `--field-sort-artist`, `--field-sort-year`, or `--field-sort-month` to override the expected field names if yours differ.
+
+**What happens on each run:**
+
+| Run | Behavior | Time (300 records) |
+|-----|----------|--------------------|
+| First run | Computes everything, writes sort data back to Discogs | ~24 min |
+| Subsequent runs | Reads persisted data, skips API lookups | ~6 sec |
+| New records added | Only new records computed, rest from cache | ~36 sec per 5 new |
+| `--force-reparse` | Recomputes everything from scratch | ~24 min |
+
+You can also edit persisted values directly in the Discogs UI — your manual edits will be preserved unless you run with `--force-reparse`.
 
 ### Artist Aliases
 
@@ -88,6 +125,8 @@ vinyl_sorter/           # Main Python package
   parser.py             # Parse sort_artist and sort_year
   sorter.py             # Sort the collection
   exporter.py           # Export to CSV
+  persistence.py        # Write sort data back to Discogs custom fields
+docs/                   # Design documents and research
 archive/                # Old exploration scripts (preserved for reference)
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ python -m vinyl_sorter --help
 | `--field-sort-artist` | `Sort Artist` | Discogs custom field name for sort artist |
 | `--field-sort-year` | `Sort Year` | Discogs custom field name for sort year |
 | `--field-sort-month` | `Sort Month` | Discogs custom field name for sort month |
+| `--field-is-compilation` | `Is Compilation` | Discogs custom field name for compilation flag |
 
 ### First-Time Setup: Discogs Custom Fields
 
@@ -44,10 +45,11 @@ VinylSorter can save computed sort data back to your Discogs account so that sub
 **One-time setup (takes 30 seconds):**
 
 1. Go to your [Discogs Collection Settings](https://www.discogs.com/settings/collection)
-2. Under **Collection Notes**, add three new custom fields:
+2. Under **Collection Notes**, add four new custom fields:
    - **Sort Artist** — type: Textarea
    - **Sort Year** — type: Textarea
    - **Sort Month** — type: Textarea
+   - **Is Compilation** — type: Textarea
 3. Save your settings
 
 The field names must match exactly (case-insensitive). VinylSorter auto-detects them by name when it starts up and will tell you what it found:

--- a/docs/discogs-custom-fields-research.md
+++ b/docs/discogs-custom-fields-research.md
@@ -1,0 +1,178 @@
+# Discogs Custom Fields — Research for Issue #5
+
+## How Custom Fields Work
+
+Discogs allows users to define **custom note fields** on their collection items. These are configured per-user at:
+- **UI:** Settings → Collection → Collection Notes ([link](https://www.discogs.com/settings/collection))
+- **API:** `GET /users/{username}/collection/fields`
+
+Each field has:
+- `field_id` — integer identifier (auto-assigned by Discogs)
+- `name` — user-defined label
+- `type` — `textarea` or `dropdown`
+- `position` — display order
+- `public` — whether visible to other users
+
+Default fields include a "Notes" field (field_id typically 3) and a "Media Condition"/"Sleeve Condition" dropdown.
+
+Users can add custom fields beyond the defaults. **There's no documented limit** on count, but forum consensus suggests keeping it reasonable (<10 fields).
+
+## API Endpoints
+
+### Read Custom Fields Definition
+```
+GET /users/{username}/collection/fields
+```
+Returns the list of all defined custom fields. Requires authentication as the collection owner.
+
+### Read Field Values on Collection Items
+When fetching collection releases:
+```
+GET /users/{username}/collection/folders/{folder_id}/releases/{release_id}
+```
+The response includes a `notes` array on each instance:
+```json
+{
+  "notes": [
+    {"field_id": 3, "value": "Near Mint condition"},
+    {"field_id": 4, "value": "Garcia"},
+    {"field_id": 5, "value": "1972"},
+    {"field_id": 6, "value": "3"}
+  ]
+}
+```
+
+**Important:** The `notes` section is only returned when authenticated as the collection owner. The general collection folder listing (`collection_folders[0].releases`) also carries these notes per instance.
+
+### Write Field Values
+```
+POST /users/{username}/collection/folders/{folder_id}/releases/{release_id}/instances/{instance_id}/fields/{field_id}
+```
+Body: `{"value": "new value"}`
+
+- Requires authentication as the collection owner
+- Each instance has an `instance_id` (different from `release_id`)
+- You must know the `instance_id`, `folder_id`, and `field_id`
+- Setting a value to empty string (`""`) or a space (`" "`) is the only way to "clear" a field — `null` doesn't work
+- **Rate limit:** Same as all Discogs API calls — 60 requests/minute for authenticated users
+
+## Python Client Library (`python3-discogs-client`)
+
+Based on the [GitHub discussion #166](https://github.com/joalla/discogs_client/discussions/166), the library has **limited support** for custom fields:
+
+- **Reading:** `CollectionItemInstance` objects have a `notes` property that returns the custom fields when the data is fetched. However, this may require accessing `.data` directly rather than a first-class property.
+- **Writing:** There is **no built-in method** for writing custom fields. We'll need to make direct HTTP requests through the client's internal `_request` method or use `requests` directly with the auth token.
+
+### Reading Notes (current library)
+```python
+for item in user.collection_folders[0].releases:
+    instance_data = item.data  # or item.fetch('notes')
+    notes = instance_data.get('notes', [])
+    for note in notes:
+        print(f"Field {note['field_id']}: {note['value']}")
+```
+
+### Writing Notes (direct API call needed)
+```python
+# Using the client's internal session
+url = f"/users/{username}/collection/folders/{folder_id}/releases/{release_id}/instances/{instance_id}/fields/{field_id}"
+client._post(url, data={"value": "Garcia"})
+```
+
+Or fall back to raw requests with the token.
+
+## Proposed Implementation Plan
+
+### Phase 1: Setup (one-time user action)
+Quinn creates 3 custom fields in Discogs collection settings:
+- **Sort Artist** (textarea)
+- **Sort Year** (textarea)
+- **Sort Month** (textarea)
+
+Then we store the field_ids in config or auto-detect them by name.
+
+### Phase 2: Read on Load
+Modify `loader.py` to capture:
+- `instance_id` (needed for write-back)
+- `folder_id` (needed for write-back)
+- Custom field values from the `notes` array
+
+New fields on `VinylRecord`:
+- `instance_id: int`
+- `folder_id: int`
+- `persisted_sort_artist: Optional[str]`
+- `persisted_sort_year: Optional[int]`
+- `persisted_sort_month: Optional[int]`
+
+### Phase 3: Skip Computed Fields
+In `parser.py`, if persisted values exist → use them, skip API lookups:
+```python
+if record.persisted_sort_artist:
+    record.sort_artist = record.persisted_sort_artist
+else:
+    record.sort_artist = record.compute_sort_artist(api)
+```
+
+### Phase 4: Write Back After Parse
+New method in `discogs_api.py`:
+```python
+def write_custom_field(self, username, folder_id, release_id, instance_id, field_id, value):
+    """Write a value to a custom field on a collection instance."""
+```
+
+After parsing, write computed values back for any record that:
+- Had no persisted value, OR
+- Was forced via `--force-reparse`
+
+### Phase 5: CLI Flags
+- `--force-reparse` — ignore persisted values, recompute everything, write back
+- `--no-write-back` — compute but don't save to Discogs (dry run)
+
+## Performance Estimate
+
+**Current (no persistence):**
+| Step | API calls per record | Total for 300 records |
+|------|--------------------|-----------------------|
+| Load collection | 0 (paginated bulk) | ~6 pages |
+| Lookup artist type | 1 | ~200 (deduplicated) |
+| Lookup master fields | 1 | 300 |
+| Lookup live year | 0.1 (only live) | ~30 |
+| **Total** | | **~530 calls ≈ 9 min** |
+
+**With persistence (subsequent runs, no new records):**
+| Step | API calls per record | Total for 300 records |
+|------|--------------------|-----------------------|
+| Load collection + read fields | 0 (included in load) | ~6 pages |
+| Skip all lookups | 0 | 0 |
+| **Total** | | **~6 calls ≈ 6 sec** |
+
+**With persistence (5 new records):**
+| Step | API calls |
+|------|-----------|
+| Load collection | ~6 pages |
+| Lookup new records | ~15 |
+| Write back new records | ~15 (3 fields × 5 records) |
+| **Total** | **~36 calls ≈ 36 sec** |
+
+**First run with write-back (one-time cost):**
+| Step | API calls |
+|------|-----------|
+| Normal full run | ~530 |
+| Write back all records | ~900 (3 fields × 300 records) |
+| **Total** | **~1430 calls ≈ 24 min** |
+
+## Gotchas & Limitations
+
+1. **Instance ID required for writes** — Each physical copy in your collection has an `instance_id`. We must capture this during load. The current loader doesn't track it.
+
+2. **No bulk write API** — Each field on each instance is a separate POST. For 300 records × 3 fields = 900 write calls on first run. At 60/min = 15 minutes of writes alone.
+
+3. **Field values are strings** — Even year/month need to be stored as strings and parsed back.
+
+4. **User manual edits win** — If Quinn edits a value in the Discogs UI, we should detect that it differs from what we'd compute and preserve the manual edit. This needs a `--force-reparse` to override.
+
+5. **Notes only visible to authenticated owner** — Won't affect other users viewing Quinn's collection.
+
+6. **Dropdown vs textarea** — We should use `textarea` type for all three fields, since dropdown requires predefined values.
+
+7. **Rate limiting on writes** — The first run with write-back will be slow. Consider a `--write-back` flag that's opt-in rather than automatic, to avoid surprise slow runs.

--- a/vinyl_sorter/__main__.py
+++ b/vinyl_sorter/__main__.py
@@ -9,6 +9,7 @@ from .discogs_api import DiscogsAPI
 from .exporter import export_collection
 from .loader import load_collection
 from .parser import load_aliases, parse_collection
+from .persistence import write_back_sort_data
 from .sorter import sort_collection
 
 
@@ -38,19 +39,64 @@ def main() -> None:
     logger.info("Starting VinylSorter…")
     api = DiscogsAPI(user_agent=config.discogs_user_agent, token=config.discogs_token)
 
-    # Load
-    records = load_collection(api, folder_index=config.folder_index)
+    # Resolve custom field IDs for persistence
+    field_ids = api.resolve_field_ids({
+        "sort_artist": config.field_sort_artist,
+        "sort_year": config.field_sort_year,
+        "sort_month": config.field_sort_month,
+    })
+
+    has_fields = any(v is not None for v in field_ids.values())
+    if has_fields:
+        found = [f"{k}→{v}" for k, v in field_ids.items() if v is not None]
+        missing = [k for k, v in field_ids.items() if v is None]
+        print(f"Custom fields found: {', '.join(found)}")
+        if missing:
+            print(f"Custom fields not found (will skip): {', '.join(missing)}")
+    else:
+        print(
+            "No custom fields found in Discogs. Sort data will not be persisted.\n"
+            "To enable persistence, create 'Sort Artist', 'Sort Year', and "
+            "'Sort Month' text fields in your Discogs collection settings."
+        )
+
+    # Load (reads persisted custom field values if available)
+    records = load_collection(
+        api,
+        folder_index=config.folder_index,
+        field_ids=field_ids if has_fields else None,
+    )
     logger.info("Loaded %d records.", len(records))
 
-    # Parse
+    # Parse (skips API lookups when persisted values exist)
     aliases = load_aliases(config.alias_file)
-    parse_collection(records, api, aliases=aliases)
+    computed_count = parse_collection(
+        records, api, aliases=aliases, force_reparse=config.force_reparse,
+    )
+
+    if config.force_reparse:
+        print(f"Force-reparsed all {len(records)} records.")
+    elif computed_count > 0:
+        print(f"Computed sort data for {computed_count} records (others used persisted values).")
+    else:
+        print("All records had persisted sort data — no API lookups needed!")
 
     # Sort
     sorted_records = sort_collection(records)
 
     # Export
     export_collection(sorted_records, output_file=config.output_file, delimiter=config.delimiter)
+
+    # Write back (unless --no-write-back)
+    if has_fields and not config.no_write_back:
+        print("Writing sort data back to Discogs…")
+        write_count = write_back_sort_data(sorted_records, api, field_ids)
+        if write_count > 0:
+            print(f"Updated {write_count} custom field values in Discogs.")
+        else:
+            print("No changes to write back.")
+    elif config.no_write_back:
+        print("Skipping write-back (--no-write-back).")
 
     print(f"Done! {len(sorted_records)} records sorted → {config.output_file}")
 

--- a/vinyl_sorter/__main__.py
+++ b/vinyl_sorter/__main__.py
@@ -47,17 +47,29 @@ def main() -> None:
     })
 
     has_fields = any(v is not None for v in field_ids.values())
+    field_name_map = {
+        "sort_artist": config.field_sort_artist,
+        "sort_year": config.field_sort_year,
+        "sort_month": config.field_sort_month,
+    }
     if has_fields:
-        found = [f"{k}→{v}" for k, v in field_ids.items() if v is not None]
-        missing = [k for k, v in field_ids.items() if v is None]
-        print(f"Custom fields found: {', '.join(found)}")
+        found = [f"{k} ('{field_name_map[k]}' → field {v})" for k, v in field_ids.items() if v is not None]
+        missing = [f"{k} (expected '{field_name_map[k]}')" for k, v in field_ids.items() if v is None]
+        print(f"\u2705 Custom fields found: {', '.join(found)}")
         if missing:
-            print(f"Custom fields not found (will skip): {', '.join(missing)}")
+            print(f"\u26a0\ufe0f  Custom fields not found: {', '.join(missing)}")
+            print("  Persistence will be skipped for missing fields.")
+            print("  Check your Discogs collection settings or use --field-sort-* flags.")
     else:
         print(
-            "No custom fields found in Discogs. Sort data will not be persisted.\n"
-            "To enable persistence, create 'Sort Artist', 'Sort Year', and "
-            "'Sort Month' text fields in your Discogs collection settings."
+            "\u26a0\ufe0f  No custom fields found in Discogs. Sort data will not be persisted.\n"
+            "  To enable persistence, create these textarea fields in your\n"
+            f"  Discogs collection settings (https://www.discogs.com/settings/collection):\n"
+            f"    - '{config.field_sort_artist}'\n"
+            f"    - '{config.field_sort_year}'\n"
+            f"    - '{config.field_sort_month}'\n"
+            "  Field names must match exactly (case-insensitive).\n"
+            "  Or use --field-sort-artist/year/month to match your existing field names."
         )
 
     # Load (reads persisted custom field values if available)

--- a/vinyl_sorter/__main__.py
+++ b/vinyl_sorter/__main__.py
@@ -44,6 +44,7 @@ def main() -> None:
         "sort_artist": config.field_sort_artist,
         "sort_year": config.field_sort_year,
         "sort_month": config.field_sort_month,
+        "is_compilation": config.field_is_compilation,
     })
 
     has_fields = any(v is not None for v in field_ids.values())
@@ -51,6 +52,7 @@ def main() -> None:
         "sort_artist": config.field_sort_artist,
         "sort_year": config.field_sort_year,
         "sort_month": config.field_sort_month,
+        "is_compilation": config.field_is_compilation,
     }
     if has_fields:
         found = [f"{k} ('{field_name_map[k]}' → field {v})" for k, v in field_ids.items() if v is not None]
@@ -68,8 +70,9 @@ def main() -> None:
             f"    - '{config.field_sort_artist}'\n"
             f"    - '{config.field_sort_year}'\n"
             f"    - '{config.field_sort_month}'\n"
+            f"    - '{config.field_is_compilation}'\n"
             "  Field names must match exactly (case-insensitive).\n"
-            "  Or use --field-sort-artist/year/month to match your existing field names."
+            "  Or use --field-* flags to match your existing field names."
         )
 
     # Load (reads persisted custom field values if available)

--- a/vinyl_sorter/cli.py
+++ b/vinyl_sorter/cli.py
@@ -110,5 +110,10 @@ def parse_args(argv=None) -> argparse.Namespace:
         default="Sort Month",
         help="Name of the Discogs custom field for sort month (default: 'Sort Month')",
     )
+    persist.add_argument(
+        "--field-is-compilation",
+        default="Is Compilation",
+        help="Name of the Discogs custom field for compilation flag (default: 'Is Compilation')",
+    )
 
     return parser.parse_args(argv)

--- a/vinyl_sorter/cli.py
+++ b/vinyl_sorter/cli.py
@@ -81,4 +81,34 @@ def parse_args(argv=None) -> argparse.Namespace:
         help="JSON file mapping artist names to sort aliases",
     )
 
+    # Persistence
+    persist = parser.add_argument_group("Persistence (Discogs custom fields)")
+    persist.add_argument(
+        "--force-reparse",
+        action="store_true",
+        default=False,
+        help="Ignore persisted sort data and recompute everything",
+    )
+    persist.add_argument(
+        "--no-write-back",
+        action="store_true",
+        default=False,
+        help="Don't write computed sort data back to Discogs",
+    )
+    persist.add_argument(
+        "--field-sort-artist",
+        default="Sort Artist",
+        help="Name of the Discogs custom field for sort artist (default: 'Sort Artist')",
+    )
+    persist.add_argument(
+        "--field-sort-year",
+        default="Sort Year",
+        help="Name of the Discogs custom field for sort year (default: 'Sort Year')",
+    )
+    persist.add_argument(
+        "--field-sort-month",
+        default="Sort Month",
+        help="Name of the Discogs custom field for sort month (default: 'Sort Month')",
+    )
+
     return parser.parse_args(argv)

--- a/vinyl_sorter/config.py
+++ b/vinyl_sorter/config.py
@@ -37,6 +37,7 @@ class Config:
     field_sort_artist: str = "Sort Artist"
     field_sort_year: str = "Sort Year"
     field_sort_month: str = "Sort Month"
+    field_is_compilation: str = "Is Compilation"
 
     @classmethod
     def from_args(cls, args) -> "Config":
@@ -61,4 +62,5 @@ class Config:
             field_sort_artist=args.field_sort_artist,
             field_sort_year=args.field_sort_year,
             field_sort_month=args.field_sort_month,
+            field_is_compilation=args.field_is_compilation,
         )

--- a/vinyl_sorter/config.py
+++ b/vinyl_sorter/config.py
@@ -5,7 +5,7 @@ variables, or config files — never hardcoded.
 """
 
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 
@@ -31,6 +31,13 @@ class Config:
     # Artist alias file (JSON mapping artist name → sort alias)
     alias_file: Optional[str] = None
 
+    # Persistence options
+    force_reparse: bool = False
+    no_write_back: bool = False
+    field_sort_artist: str = "Sort Artist"
+    field_sort_year: str = "Sort Year"
+    field_sort_month: str = "Sort Month"
+
     @classmethod
     def from_args(cls, args) -> "Config":
         """Build config from parsed CLI arguments, falling back to env vars."""
@@ -49,4 +56,9 @@ class Config:
             log_file=args.log_file,
             log_level=args.log_level.upper(),
             alias_file=args.alias_file,
+            force_reparse=args.force_reparse,
+            no_write_back=args.no_write_back,
+            field_sort_artist=args.field_sort_artist,
+            field_sort_year=args.field_sort_year,
+            field_sort_month=args.field_sort_month,
         )

--- a/vinyl_sorter/constants.py
+++ b/vinyl_sorter/constants.py
@@ -25,3 +25,7 @@ LIVE_KEYWORDS = ["live", "recorded at", "concert", "venue"]
 
 # Artist names that indicate a compilation / various-artists release
 COMPILATION_ARTISTS = {"Various", "Various Artists"}
+
+# Pattern matching parenthetical disambiguation numbers from Discogs
+# e.g. "Wings (2)" → "Wings"
+PARENTHETICAL_NUMBER_RE = r"\s*\(\d+\)\s*$"

--- a/vinyl_sorter/constants.py
+++ b/vinyl_sorter/constants.py
@@ -21,7 +21,7 @@ class RecordingType(str, Enum):
 INSIGNIFICANT_LEADING_WORDS = {"The", "A", "An"}
 
 # Keywords that indicate a live recording
-LIVE_KEYWORDS = ["live", "recorded at", "concert", "venue"]
+LIVE_KEYWORDS = ["live", "recorded live", "live at", "live in", "performed live", "concert", "venue"]
 
 # Artist names that indicate a compilation / various-artists release
 COMPILATION_ARTISTS = {"Various", "Various Artists"}

--- a/vinyl_sorter/constants.py
+++ b/vinyl_sorter/constants.py
@@ -20,8 +20,13 @@ class RecordingType(str, Enum):
 # Words to strip from the beginning of group names for sorting
 INSIGNIFICANT_LEADING_WORDS = {"The", "A", "An"}
 
-# Keywords that indicate a live recording
-LIVE_KEYWORDS = ["live", "recorded live", "live at", "live in", "performed live", "concert", "venue"]
+# Keywords that indicate a live recording.
+# LIVE_KEYWORDS_TITLE  — broad set, safe for title scanning ("live" in a title
+#                        almost always means a live album).
+# LIVE_KEYWORDS_NOTES  — stricter phrases for notes scanning (bare "live" appears
+#                        too often in studio album notes — bonus tracks, credits, etc.).
+LIVE_KEYWORDS_TITLE = ["live", "recorded live", "live at", "live in", "performed live", "concert", "venue"]
+LIVE_KEYWORDS_NOTES = ["recorded live", "live at", "live in", "performed live", "live concert"]
 
 # Artist names that indicate a compilation / various-artists release
 COMPILATION_ARTISTS = {"Various", "Various Artists"}

--- a/vinyl_sorter/discogs_api.py
+++ b/vinyl_sorter/discogs_api.py
@@ -106,10 +106,10 @@ class DiscogsAPI:
 
     # -- Release / Master -----------------------------------------------------
 
-    def lookup_master_fields(self, release_id: int) -> Tuple[bool, str, int]:
-        """Return (master_exists, master_title, master_year) for a release.
+    def lookup_master_fields(self, release_id: int) -> Tuple[bool, str, int, int]:
+        """Return (master_exists, master_title, master_year, master_month) for a release.
 
-        Returns (False, "Unknown", -1) if the release or master cannot
+        Returns (False, "Unknown", -1, 0) if the release or master cannot
         be fetched (e.g. empty API response, network errors).
         """
         try:
@@ -117,12 +117,30 @@ class DiscogsAPI:
             if release_info.master:
                 title = release_info.master.title
                 year = release_info.master.year
-                logger.debug("Found master '%s' dated %s", title, year)
-                return True, title, year
+                # Try to get month from the master's main_release date
+                month = 0
+                try:
+                    main_release = release_info.master.main_release
+                    if main_release:
+                        date_str = getattr(main_release, 'date_added', '') or ''
+                        # Also check data dict for released date
+                        data = getattr(main_release, 'data', {}) or {}
+                        released = data.get('released', '') or ''
+                        if released and '-' in released:
+                            parts = released.split('-')
+                            if len(parts) >= 2:
+                                try:
+                                    month = int(parts[1])
+                                except (ValueError, IndexError):
+                                    pass
+                except Exception:
+                    pass  # Month extraction is best-effort
+                logger.debug("Found master '%s' dated %s-%02d", title, year, month)
+                return True, title, year, month
         except Exception as exc:
             logger.warning("Could not look up master for release %d: %s", release_id, exc)
 
-        return False, "Unknown", -1
+        return False, "Unknown", -1, 0
 
     def lookup_live_year(self, release_id: int) -> Optional[int]:
         """Search release and master text fields for a live-performance year."""

--- a/vinyl_sorter/discogs_api.py
+++ b/vinyl_sorter/discogs_api.py
@@ -79,8 +79,8 @@ class DiscogsAPI:
         self._client = discogs_client.Client(user_agent, user_token=token)
         self._user = self._client.identity()
         self._token = token
-        self._username = str(self._user)
-        logger.info("Logged into Discogs as %s", self._user)
+        self._username = self._user.username
+        logger.info("Logged into Discogs as %s", self._username)
 
     @property
     def username(self) -> str:
@@ -195,13 +195,17 @@ class DiscogsAPI:
             List of field dicts with 'id', 'name', 'type', etc.
         """
         try:
-            url = f"{self._client._base_url}/users/{self._username}/collection/fields"
-            resp = self._client._fetcher.fetch(
-                self._client, "GET", url, headers={"User-Agent": self._client.user_agent}
+            url = f"https://api.discogs.com/users/{self._username}/collection/fields"
+            resp = requests.get(
+                url,
+                headers={
+                    "User-Agent": self._client.user_agent,
+                    "Authorization": f"Discogs token={self._token}",
+                },
+                timeout=30,
             )
-            import json
-            data = json.loads(resp[2])
-            fields = data.get("fields", [])
+            resp.raise_for_status()
+            fields = resp.json().get("fields", [])
             logger.info("Found %d custom fields in Discogs collection.", len(fields))
             return fields
         except Exception as exc:
@@ -253,20 +257,20 @@ class DiscogsAPI:
         """
         try:
             url = (
-                f"{self._client._base_url}/users/{self._username}"
+                f"https://api.discogs.com/users/{self._username}"
                 f"/collection/folders/{folder_id}/releases/{release_id}"
                 f"/instances/{instance_id}/fields/{field_id}"
             )
-            self._client._fetcher.fetch(
-                self._client,
-                "POST",
+            resp = requests.post(
                 url,
-                data='{"value": "' + str(value).replace('"', '\\"') + '"}',
+                json={"value": str(value)},
                 headers={
                     "User-Agent": self._client.user_agent,
-                    "Content-Type": "application/json",
+                    "Authorization": f"Discogs token={self._token}",
                 },
+                timeout=30,
             )
+            resp.raise_for_status()
             logger.debug(
                 "Wrote field %d = '%s' on instance %d", field_id, value, instance_id
             )

--- a/vinyl_sorter/discogs_api.py
+++ b/vinyl_sorter/discogs_api.py
@@ -113,17 +113,23 @@ class DiscogsAPI:
 
     # -- Release / Master -----------------------------------------------------
 
-    def lookup_master_fields(self, release_id: int) -> Tuple[bool, str, int, int]:
-        """Return (master_exists, master_title, master_year, master_month) for a release.
+    def lookup_master_fields(self, release_id: int) -> Tuple[bool, str, int, int, str]:
+        """Return (master_exists, master_title, master_year, master_month, notes) for a release.
 
-        Returns (False, "Unknown", -1, 0) if the release or master cannot
-        be fetched (e.g. empty API response, network errors).
+        ``notes`` is the combined release + master notes text (for live-keyword
+        scanning).  Returns (False, "Unknown", -1, 0, "") if the release or
+        master cannot be fetched.
         """
         try:
             release_info = self._client.release(release_id)
+            # Collect notes from both release and master for live detection
+            release_notes = getattr(release_info, 'notes', '') or ''
+            master_notes = ''
+
             if release_info.master:
                 title = release_info.master.title
                 year = release_info.master.year
+                master_notes = getattr(release_info.master, 'notes', '') or ''
                 # Try to get month from the master's main_release date
                 month = 0
                 try:
@@ -142,12 +148,16 @@ class DiscogsAPI:
                                     pass
                 except Exception:
                     pass  # Month extraction is best-effort
+                combined_notes = f"{release_notes}\n{master_notes}".strip()
                 logger.debug("Found master '%s' dated %s-%02d", title, year, month)
-                return True, title, year, month
+                return True, title, year, month, combined_notes
+
+            # No master — still return release notes
+            return False, "Unknown", -1, 0, release_notes
         except Exception as exc:
             logger.warning("Could not look up master for release %d: %s", release_id, exc)
 
-        return False, "Unknown", -1, 0
+        return False, "Unknown", -1, 0, ""
 
     def lookup_live_year(self, release_id: int) -> Optional[int]:
         """Search release and master text fields for a live-performance year."""

--- a/vinyl_sorter/discogs_api.py
+++ b/vinyl_sorter/discogs_api.py
@@ -9,7 +9,7 @@ import functools
 import logging
 import re
 import time
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import discogs_client
 import requests
@@ -78,7 +78,14 @@ class DiscogsAPI:
     def __init__(self, user_agent: str, token: str) -> None:
         self._client = discogs_client.Client(user_agent, user_token=token)
         self._user = self._client.identity()
+        self._token = token
+        self._username = str(self._user)
         logger.info("Logged into Discogs as %s", self._user)
+
+    @property
+    def username(self) -> str:
+        """The authenticated Discogs username."""
+        return self._username
 
     # -- Collection -----------------------------------------------------------
 
@@ -178,6 +185,98 @@ class DiscogsAPI:
         except Exception as exc:
             logger.error("Error processing release %d: %s", release_id, exc)
             return None
+
+    # -- Custom Fields (persistence) ------------------------------------------
+
+    def get_custom_fields(self) -> List[Dict]:
+        """Fetch the user's collection custom field definitions.
+
+        Returns:
+            List of field dicts with 'id', 'name', 'type', etc.
+        """
+        try:
+            url = f"{self._client._base_url}/users/{self._username}/collection/fields"
+            resp = self._client._fetcher.fetch(
+                self._client, "GET", url, headers={"User-Agent": self._client.user_agent}
+            )
+            import json
+            data = json.loads(resp[2])
+            fields = data.get("fields", [])
+            logger.info("Found %d custom fields in Discogs collection.", len(fields))
+            return fields
+        except Exception as exc:
+            logger.warning("Could not fetch custom fields: %s", exc)
+            return []
+
+    def resolve_field_ids(
+        self, field_names: Dict[str, str]
+    ) -> Dict[str, Optional[int]]:
+        """Map logical field names to Discogs field IDs by matching on name.
+
+        Args:
+            field_names: Mapping of logical name → Discogs field label.
+                e.g. {"sort_artist": "Sort Artist", "sort_year": "Sort Year"}
+
+        Returns:
+            Mapping of logical name → field_id (or None if not found).
+        """
+        fields = self.get_custom_fields()
+        result: Dict[str, Optional[int]] = {k: None for k in field_names}
+
+        for f in fields:
+            for logical, label in field_names.items():
+                if f.get("name", "").strip().lower() == label.strip().lower():
+                    result[logical] = f["id"]
+                    logger.debug("Mapped '%s' → field_id %d", label, f["id"])
+
+        return result
+
+    def write_custom_field(
+        self,
+        folder_id: int,
+        release_id: int,
+        instance_id: int,
+        field_id: int,
+        value: str,
+    ) -> bool:
+        """Write a value to a custom field on a collection instance.
+
+        Args:
+            folder_id: Collection folder ID.
+            release_id: Discogs release ID.
+            instance_id: Collection instance ID.
+            field_id: Custom field ID.
+            value: Value to write (string).
+
+        Returns:
+            True if successful, False otherwise.
+        """
+        try:
+            url = (
+                f"{self._client._base_url}/users/{self._username}"
+                f"/collection/folders/{folder_id}/releases/{release_id}"
+                f"/instances/{instance_id}/fields/{field_id}"
+            )
+            self._client._fetcher.fetch(
+                self._client,
+                "POST",
+                url,
+                data='{"value": "' + str(value).replace('"', '\\"') + '"}',
+                headers={
+                    "User-Agent": self._client.user_agent,
+                    "Content-Type": "application/json",
+                },
+            )
+            logger.debug(
+                "Wrote field %d = '%s' on instance %d", field_id, value, instance_id
+            )
+            return True
+        except Exception as exc:
+            logger.warning(
+                "Failed to write field %d on instance %d: %s",
+                field_id, instance_id, exc,
+            )
+            return False
 
 
 # ---------------------------------------------------------------------------

--- a/vinyl_sorter/discogs_api.py
+++ b/vinyl_sorter/discogs_api.py
@@ -130,24 +130,26 @@ class DiscogsAPI:
                 title = release_info.master.title
                 year = release_info.master.year
                 master_notes = getattr(release_info.master, 'notes', '') or ''
-                # Try to get month from the master's main_release date
                 month = 0
+
+                # Try to extract month from the master's main release date.
+                # The Discogs API returns a 'released' field (e.g. "1969-01-12",
+                # "1969-01", or just "1969").  We fetch it via direct API call
+                # since the client library's lazy objects don't always populate
+                # the data dict reliably.
                 try:
                     main_release = release_info.master.main_release
                     if main_release:
-                        date_str = getattr(main_release, 'date_added', '') or ''
-                        # Also check data dict for released date
-                        data = getattr(main_release, 'data', {}) or {}
-                        released = data.get('released', '') or ''
-                        if released and '-' in released:
-                            parts = released.split('-')
-                            if len(parts) >= 2:
-                                try:
-                                    month = int(parts[1])
-                                except (ValueError, IndexError):
-                                    pass
+                        main_release_id = getattr(main_release, 'id', None)
+                        if main_release_id:
+                            month = self._fetch_release_month(main_release_id)
                 except Exception:
                     pass  # Month extraction is best-effort
+
+                # If main release didn't yield a month, try the release itself
+                if month == 0:
+                    month = self._fetch_release_month(release_id)
+
                 combined_notes = f"{release_notes}\n{master_notes}".strip()
                 logger.debug("Found master '%s' dated %s-%02d", title, year, month)
                 return True, title, year, month, combined_notes
@@ -158,6 +160,38 @@ class DiscogsAPI:
             logger.warning("Could not look up master for release %d: %s", release_id, exc)
 
         return False, "Unknown", -1, 0, ""
+
+    def _fetch_release_month(self, release_id: int) -> int:
+        """Fetch the release month from the Discogs API 'released' field.
+
+        The 'released' field can be 'YYYY-MM-DD', 'YYYY-MM', or just 'YYYY'.
+        Returns 1–12 if a month is found, 0 otherwise.
+        """
+        try:
+            url = f"https://api.discogs.com/releases/{release_id}"
+            resp = requests.get(
+                url,
+                headers={
+                    "User-Agent": self._client.user_agent,
+                    "Authorization": f"Discogs token={self._token}",
+                },
+                timeout=30,
+            )
+            resp.raise_for_status()
+            released = resp.json().get("released", "") or ""
+            if released and "-" in released:
+                parts = released.split("-")
+                if len(parts) >= 2:
+                    month = int(parts[1])
+                    if 1 <= month <= 12:
+                        logger.debug(
+                            "Extracted month %d from release %d ('%s')",
+                            month, release_id, released,
+                        )
+                        return month
+        except Exception as exc:
+            logger.debug("Could not fetch month for release %d: %s", release_id, exc)
+        return 0
 
     def lookup_live_year(self, release_id: int) -> Optional[int]:
         """Search release and master text fields for a live-performance year."""

--- a/vinyl_sorter/exporter.py
+++ b/vinyl_sorter/exporter.py
@@ -23,7 +23,10 @@ def export_collection(
     """
     logger.info("Saving sorted collection to '%s'…", output_file)
 
-    headers = ["Sort #", "Sort Artist", "Artist", "Album", "Sort Year", "Year", "Live", "Compilation"]
+    headers = [
+        "Sort #", "Sort Artist", "Artist", "Album",
+        "Sort Year", "Sort Month", "Year", "Live", "Compilation",
+    ]
 
     with open(output_file, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=headers, delimiter=delimiter)
@@ -36,6 +39,7 @@ def export_collection(
                 "Artist": record.release_artist,
                 "Album": record.release_title,
                 "Sort Year": record.sort_year,
+                "Sort Month": record.sort_month if record.sort_month else "",
                 "Year": record.release_year,
                 "Live": "Yes" if record.is_live else "",
                 "Compilation": "Yes" if record.is_compilation else "",

--- a/vinyl_sorter/loader.py
+++ b/vinyl_sorter/loader.py
@@ -74,7 +74,7 @@ def load_collection(
             release_artist_id=release.artists[0].id,
             release_title=release.title,
             release_year=release.year,
-            instance_id=getattr(item, "id", -1),
+            instance_id=getattr(item, "instance_id", -1),
             folder_id=getattr(item, "folder_id", folder_index),
             persisted_sort_artist=persisted_artist,
             persisted_sort_year=persisted_year,

--- a/vinyl_sorter/loader.py
+++ b/vinyl_sorter/loader.py
@@ -38,6 +38,7 @@ def load_collection(
         persisted_artist = None
         persisted_year = None
         persisted_month = None
+        persisted_compilation = None
 
         notes = getattr(item, "notes", None) or []
         # Some client versions put notes in .data
@@ -64,6 +65,8 @@ def load_collection(
                         persisted_month = int(val)
                     except ValueError:
                         logger.warning("Invalid persisted sort_month '%s'", val)
+                elif fid == field_ids.get("is_compilation"):
+                    persisted_compilation = val.lower() in ("yes", "true", "1")
 
         record = VinylRecord(
             discogs_id=release.id,
@@ -76,6 +79,7 @@ def load_collection(
             persisted_sort_artist=persisted_artist,
             persisted_sort_year=persisted_year,
             persisted_sort_month=persisted_month,
+            persisted_is_compilation=persisted_compilation,
         )
 
         if persisted_artist:

--- a/vinyl_sorter/loader.py
+++ b/vinyl_sorter/loader.py
@@ -1,7 +1,7 @@
 """Load a vinyl collection from Discogs."""
 
 import logging
-from typing import List
+from typing import Dict, List, Optional
 
 from .discogs_api import DiscogsAPI
 from .models import VinylRecord
@@ -9,28 +9,81 @@ from .models import VinylRecord
 logger = logging.getLogger(__name__)
 
 
-def load_collection(api: DiscogsAPI, folder_index: int = 0) -> List[VinylRecord]:
+def load_collection(
+    api: DiscogsAPI,
+    folder_index: int = 0,
+    field_ids: Optional[Dict[str, Optional[int]]] = None,
+) -> List[VinylRecord]:
     """Fetch all releases from a Discogs collection folder.
 
     Args:
         api: Authenticated Discogs API session.
         folder_index: Collection folder index (0 = all items).
+        field_ids: Mapping of logical name → Discogs field_id for
+            reading persisted sort data. Keys: 'sort_artist',
+            'sort_year', 'sort_month'.
 
     Returns:
-        List of VinylRecord objects with Discogs source fields populated.
+        List of VinylRecord objects with Discogs source fields populated,
+        including any persisted custom field values.
     """
     logger.info("Loading collection from Discogs folder %d…", folder_index)
+    field_ids = field_ids or {}
     records: List[VinylRecord] = []
 
     for item in api.collection_releases(folder_index):
         release = item.release
+
+        # Extract persisted custom field values from notes
+        persisted_artist = None
+        persisted_year = None
+        persisted_month = None
+
+        notes = getattr(item, "notes", None) or []
+        # Some client versions put notes in .data
+        if not notes:
+            data = getattr(item, "data", {}) or {}
+            notes = data.get("notes", [])
+
+        if notes and field_ids:
+            for note in notes:
+                fid = note.get("field_id")
+                val = (note.get("value") or "").strip()
+                if not val:
+                    continue
+
+                if fid == field_ids.get("sort_artist"):
+                    persisted_artist = val
+                elif fid == field_ids.get("sort_year"):
+                    try:
+                        persisted_year = int(val)
+                    except ValueError:
+                        logger.warning("Invalid persisted sort_year '%s'", val)
+                elif fid == field_ids.get("sort_month"):
+                    try:
+                        persisted_month = int(val)
+                    except ValueError:
+                        logger.warning("Invalid persisted sort_month '%s'", val)
+
         record = VinylRecord(
             discogs_id=release.id,
             release_artist=release.artists[0].name,
             release_artist_id=release.artists[0].id,
             release_title=release.title,
             release_year=release.year,
+            instance_id=getattr(item, "id", -1),
+            folder_id=getattr(item, "folder_id", folder_index),
+            persisted_sort_artist=persisted_artist,
+            persisted_sort_year=persisted_year,
+            persisted_sort_month=persisted_month,
         )
+
+        if persisted_artist:
+            logger.debug(
+                "Loaded persisted sort data for %s: artist='%s' year=%s month=%s",
+                record, persisted_artist, persisted_year, persisted_month,
+            )
+
         logger.info("Loaded item #%d %s", record.import_number, record)
         records.append(record)
 

--- a/vinyl_sorter/models.py
+++ b/vinyl_sorter/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Tuple, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from .constants import (
     ArtistType,
@@ -48,6 +48,15 @@ class VinylRecord:
     release_artist_id: int = -1
     release_title: str = "None"
     release_year: int = -1
+
+    # Discogs collection instance fields (needed for write-back)
+    instance_id: int = -1
+    folder_id: int = 0
+
+    # Persisted values from Discogs custom fields (None = not yet stored)
+    persisted_sort_artist: Optional[str] = None
+    persisted_sort_year: Optional[int] = None
+    persisted_sort_month: Optional[int] = None
 
     # Derived fields (populated during parsing)
     release_artist_type: ArtistType = ArtistType.UNKNOWN

--- a/vinyl_sorter/models.py
+++ b/vinyl_sorter/models.py
@@ -11,7 +11,8 @@ from .constants import (
     ArtistType,
     COMPILATION_ARTISTS,
     INSIGNIFICANT_LEADING_WORDS,
-    LIVE_KEYWORDS,
+    LIVE_KEYWORDS_NOTES,
+    LIVE_KEYWORDS_TITLE,
     PARENTHETICAL_NUMBER_RE,
 )
 
@@ -149,16 +150,22 @@ class VinylRecord:
             field_to_check = master_title
             logger.debug("Have master title '%s' dated %s-%02d", master_title, master_year, master_month)
 
-        # Check if this is a live recording (scan title AND notes)
-        # Use word-boundary matching to avoid false positives like
-        # "Avenue" matching "venue" or "delivered" matching "live".
-        text_to_scan = f"{field_to_check}\n{notes}".strip()
+        # Check if this is a live recording.
+        # Title gets broad keywords ("live" in a title almost always means live album).
+        # Notes get stricter phrases (bare "live" appears too often in studio credits).
+        # Word-boundary matching avoids "Avenue" → "venue" etc.
         logger.debug("Scanning title + notes for live markers on '%s'", self.release_title)
-        self.is_live = any(
-            re.search(rf"\b{re.escape(kw)}\b", text_to_scan, re.IGNORECASE)
-            for kw in LIVE_KEYWORDS
+        title_match = any(
+            re.search(rf"\b{re.escape(kw)}\b", field_to_check, re.IGNORECASE)
+            for kw in LIVE_KEYWORDS_TITLE
         )
-        logger.debug("Determined '%s' as live recording: %s", self.release_title, self.is_live)
+        notes_match = bool(notes) and any(
+            re.search(rf"\b{re.escape(kw)}\b", notes, re.IGNORECASE)
+            for kw in LIVE_KEYWORDS_NOTES
+        )
+        self.is_live = title_match or notes_match
+        logger.debug("Determined '%s' as live recording: %s (title=%s, notes=%s)",
+                     self.release_title, self.is_live, title_match, notes_match)
 
         if self.is_live:
             live_year = api.lookup_live_year(self.discogs_id)

--- a/vinyl_sorter/models.py
+++ b/vinyl_sorter/models.py
@@ -140,7 +140,7 @@ class VinylRecord:
         field_to_check = self.release_title
 
         # Check for a master release (original release date)
-        master_exists, master_title, master_year, master_month = api.lookup_master_fields(
+        master_exists, master_title, master_year, master_month, notes = api.lookup_master_fields(
             self.discogs_id
         )
         if master_exists:
@@ -149,10 +149,11 @@ class VinylRecord:
             field_to_check = master_title
             logger.debug("Have master title '%s' dated %s-%02d", master_title, master_year, master_month)
 
-        # Check if this is a live recording
-        logger.debug("Scanning '%s' for live markers", field_to_check)
+        # Check if this is a live recording (scan title AND notes)
+        text_to_scan = f"{field_to_check}\n{notes}".strip()
+        logger.debug("Scanning title + notes for live markers on '%s'", self.release_title)
         self.is_live = any(
-            kw.lower() in field_to_check.lower() for kw in LIVE_KEYWORDS
+            kw.lower() in text_to_scan.lower() for kw in LIVE_KEYWORDS
         )
         logger.debug("Determined '%s' as live recording: %s", self.release_title, self.is_live)
 

--- a/vinyl_sorter/models.py
+++ b/vinyl_sorter/models.py
@@ -57,6 +57,7 @@ class VinylRecord:
     persisted_sort_artist: Optional[str] = None
     persisted_sort_year: Optional[int] = None
     persisted_sort_month: Optional[int] = None
+    persisted_is_compilation: Optional[bool] = None
 
     # Derived fields (populated during parsing)
     release_artist_type: ArtistType = ArtistType.UNKNOWN

--- a/vinyl_sorter/models.py
+++ b/vinyl_sorter/models.py
@@ -5,19 +5,32 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple, Optional
 
 from .constants import (
     ArtistType,
     COMPILATION_ARTISTS,
     INSIGNIFICANT_LEADING_WORDS,
     LIVE_KEYWORDS,
+    PARENTHETICAL_NUMBER_RE,
 )
 
 if TYPE_CHECKING:
     from .discogs_api import DiscogsAPI
 
 logger = logging.getLogger(__name__)
+
+
+def clean_artist_name(name: str) -> str:
+    """Strip Discogs disambiguation suffixes like '(2)' from artist names.
+
+    Args:
+        name: Raw artist name from Discogs.
+
+    Returns:
+        Cleaned artist name.
+    """
+    return re.sub(PARENTHETICAL_NUMBER_RE, "", name).strip()
 
 
 @dataclass
@@ -42,6 +55,7 @@ class VinylRecord:
     is_live: bool = False
     sort_artist: str = "None"
     sort_year: int = -1
+    sort_month: int = 0  # 0 = unknown; 1–12 = Jan–Dec
     sort_sequence: int = -1
 
     # Import order tracking
@@ -54,6 +68,8 @@ class VinylRecord:
         VinylRecord._import_counter += 1
         if self.import_number == -1:
             self.import_number = VinylRecord._import_counter
+        # Clean parenthetical numbers from artist name on load (#6)
+        self.release_artist = clean_artist_name(self.release_artist)
 
     def __repr__(self) -> str:
         return f"'{self.release_title}' by {self.release_artist}"
@@ -100,21 +116,28 @@ class VinylRecord:
         )
         return self.release_artist
 
-    def compute_sort_year(self, api: DiscogsAPI) -> int:
-        """Determine the best year for chronological sorting.
+    def compute_sort_date(self, api: DiscogsAPI) -> Tuple[int, int]:
+        """Determine the best year and month for chronological sorting.
 
-        Re-releases → original (master) release year.
+        Re-releases → original (master) release year/month.
         Live albums  → performance year extracted from text fields.
+
+        Returns:
+            (year, month) tuple. Month is 0 if unknown.
         """
         parsed_year = self.release_year
+        parsed_month = 0
         field_to_check = self.release_title
 
         # Check for a master release (original release date)
-        master_exists, master_title, master_year = api.lookup_master_fields(self.discogs_id)
+        master_exists, master_title, master_year, master_month = api.lookup_master_fields(
+            self.discogs_id
+        )
         if master_exists:
             parsed_year = master_year
+            parsed_month = master_month
             field_to_check = master_title
-            logger.debug("Have master title '%s' dated '%s'", master_title, master_year)
+            logger.debug("Have master title '%s' dated %s-%02d", master_title, master_year, master_month)
 
         # Check if this is a live recording
         logger.debug("Scanning '%s' for live markers", field_to_check)
@@ -127,5 +150,6 @@ class VinylRecord:
             live_year = api.lookup_live_year(self.discogs_id)
             if live_year is not None and live_year != -1:
                 parsed_year = live_year
+                parsed_month = 0  # Live year extraction doesn't give us month
 
-        return parsed_year
+        return parsed_year, parsed_month

--- a/vinyl_sorter/models.py
+++ b/vinyl_sorter/models.py
@@ -150,10 +150,13 @@ class VinylRecord:
             logger.debug("Have master title '%s' dated %s-%02d", master_title, master_year, master_month)
 
         # Check if this is a live recording (scan title AND notes)
+        # Use word-boundary matching to avoid false positives like
+        # "Avenue" matching "venue" or "delivered" matching "live".
         text_to_scan = f"{field_to_check}\n{notes}".strip()
         logger.debug("Scanning title + notes for live markers on '%s'", self.release_title)
         self.is_live = any(
-            kw.lower() in text_to_scan.lower() for kw in LIVE_KEYWORDS
+            re.search(rf"\b{re.escape(kw)}\b", text_to_scan, re.IGNORECASE)
+            for kw in LIVE_KEYWORDS
         )
         logger.debug("Determined '%s' as live recording: %s", self.release_title, self.is_live)
 

--- a/vinyl_sorter/parser.py
+++ b/vinyl_sorter/parser.py
@@ -84,6 +84,7 @@ def parse_collection(
 
         # --- Sort Artist ---
         used_persisted = False
+        needed_computation = False
 
         if (
             not force_reparse
@@ -117,7 +118,7 @@ def parse_collection(
             record.is_compilation = last_is_compilation
         else:
             record.sort_artist = record.compute_sort_artist(api)
-            computed_count += 1
+            needed_computation = True
 
         logger.debug("Parsed '%s' → '%s'", record.release_artist, record.sort_artist)
 
@@ -140,11 +141,14 @@ def parse_collection(
         else:
             record.sort_year, record.sort_month = record.compute_sort_date(api)
             if not used_persisted:
-                computed_count += 1
+                needed_computation = True
             logger.debug(
                 "Parsed '%s' as dated %s-%02d",
                 record.release_title, record.sort_year, record.sort_month,
             )
+
+        if needed_computation:
+            computed_count += 1
 
     logger.info(
         "Parsing complete. %d records required fresh computation.", computed_count

--- a/vinyl_sorter/parser.py
+++ b/vinyl_sorter/parser.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from .constants import COMPILATION_ARTISTS
 from .discogs_api import DiscogsAPI
 from .models import VinylRecord
 
@@ -47,7 +48,7 @@ def parse_collection(
     api: DiscogsAPI,
     aliases: Optional[Dict[str, str]] = None,
 ) -> None:
-    """Populate sort_artist and sort_year on each record.
+    """Populate sort_artist, sort_year, and sort_month on each record.
 
     Records are pre-sorted by release_artist so that consecutive records
     by the same artist can reuse the computed sort_artist (avoiding
@@ -66,19 +67,23 @@ def parse_collection(
 
     last_artist = ""
     last_sort_artist = ""
+    last_is_compilation = False
 
     for record in records:
         logger.info("Parsing %s", record)
 
-        # Check aliases first
+        # Check aliases first (using cleaned name — parentheticals already stripped)
         if record.release_artist in aliases:
             record.sort_artist = aliases[record.release_artist]
+            # Check if the alias target is a compilation
+            record.is_compilation = record.release_artist in COMPILATION_ARTISTS
             logger.debug(
                 "Applied alias: '%s' → '%s'", record.release_artist, record.sort_artist
             )
         elif record.release_artist == last_artist:
             # Reuse cached sort_artist for consecutive same-artist records
             record.sort_artist = last_sort_artist
+            record.is_compilation = last_is_compilation  # Propagate compilation flag (#7)
         else:
             record.sort_artist = record.compute_sort_artist(api)
 
@@ -86,7 +91,10 @@ def parse_collection(
 
         last_artist = record.release_artist
         last_sort_artist = record.sort_artist
+        last_is_compilation = record.is_compilation
 
-        # Compute sort year
-        record.sort_year = record.compute_sort_year(api)
-        logger.debug("Parsed '%s' as dated %s", record.release_title, record.sort_year)
+        # Compute sort date (year + month)
+        record.sort_year, record.sort_month = record.compute_sort_date(api)
+        logger.debug(
+            "Parsed '%s' as dated %s-%02d", record.release_title, record.sort_year, record.sort_month
+        )

--- a/vinyl_sorter/parser.py
+++ b/vinyl_sorter/parser.py
@@ -47,8 +47,13 @@ def parse_collection(
     records: List[VinylRecord],
     api: DiscogsAPI,
     aliases: Optional[Dict[str, str]] = None,
-) -> None:
+    force_reparse: bool = False,
+) -> int:
     """Populate sort_artist, sort_year, and sort_month on each record.
+
+    When persisted values exist on a record (from Discogs custom fields)
+    and ``force_reparse`` is False, those values are used directly and
+    the expensive API lookups are skipped.
 
     Records are pre-sorted by release_artist so that consecutive records
     by the same artist can reuse the computed sort_artist (avoiding
@@ -58,6 +63,10 @@ def parse_collection(
         records: List of VinylRecord objects to parse (modified in place).
         api: Authenticated Discogs API session.
         aliases: Optional artist alias overrides.
+        force_reparse: If True, ignore persisted values and recompute.
+
+    Returns:
+        Number of records that required fresh computation (API calls).
     """
     aliases = aliases or {}
     logger.info("Parsing collection artists & dates for sorting…")
@@ -68,14 +77,33 @@ def parse_collection(
     last_artist = ""
     last_sort_artist = ""
     last_is_compilation = False
+    computed_count = 0
 
     for record in records:
         logger.info("Parsing %s", record)
 
-        # Check aliases first (using cleaned name — parentheticals already stripped)
-        if record.release_artist in aliases:
+        # --- Sort Artist ---
+        used_persisted = False
+
+        if (
+            not force_reparse
+            and record.persisted_sort_artist is not None
+        ):
+            # Use persisted value from Discogs
+            record.sort_artist = record.persisted_sort_artist
+            # Detect compilation from persisted data
+            record.is_compilation = (
+                record.release_artist in COMPILATION_ARTISTS
+                or record.sort_artist == "Compilation"
+            )
+            used_persisted = True
+            logger.debug(
+                "Using persisted sort_artist for '%s': '%s'",
+                record.release_artist, record.sort_artist,
+            )
+        elif record.release_artist in aliases:
+            # Check aliases (using cleaned name — parentheticals already stripped)
             record.sort_artist = aliases[record.release_artist]
-            # Check if the alias target is a compilation
             record.is_compilation = record.release_artist in COMPILATION_ARTISTS
             logger.debug(
                 "Applied alias: '%s' → '%s'", record.release_artist, record.sort_artist
@@ -83,9 +111,10 @@ def parse_collection(
         elif record.release_artist == last_artist:
             # Reuse cached sort_artist for consecutive same-artist records
             record.sort_artist = last_sort_artist
-            record.is_compilation = last_is_compilation  # Propagate compilation flag (#7)
+            record.is_compilation = last_is_compilation
         else:
             record.sort_artist = record.compute_sort_artist(api)
+            computed_count += 1
 
         logger.debug("Parsed '%s' → '%s'", record.release_artist, record.sort_artist)
 
@@ -93,8 +122,28 @@ def parse_collection(
         last_sort_artist = record.sort_artist
         last_is_compilation = record.is_compilation
 
-        # Compute sort date (year + month)
-        record.sort_year, record.sort_month = record.compute_sort_date(api)
-        logger.debug(
-            "Parsed '%s' as dated %s-%02d", record.release_title, record.sort_year, record.sort_month
-        )
+        # --- Sort Date ---
+        if (
+            not force_reparse
+            and record.persisted_sort_year is not None
+            and used_persisted
+        ):
+            record.sort_year = record.persisted_sort_year
+            record.sort_month = record.persisted_sort_month or 0
+            logger.debug(
+                "Using persisted sort_date for '%s': %d-%02d",
+                record.release_title, record.sort_year, record.sort_month,
+            )
+        else:
+            record.sort_year, record.sort_month = record.compute_sort_date(api)
+            if not used_persisted:
+                computed_count += 1
+            logger.debug(
+                "Parsed '%s' as dated %s-%02d",
+                record.release_title, record.sort_year, record.sort_month,
+            )
+
+    logger.info(
+        "Parsing complete. %d records required fresh computation.", computed_count
+    )
+    return computed_count

--- a/vinyl_sorter/parser.py
+++ b/vinyl_sorter/parser.py
@@ -91,11 +91,14 @@ def parse_collection(
         ):
             # Use persisted value from Discogs
             record.sort_artist = record.persisted_sort_artist
-            # Detect compilation from persisted data
-            record.is_compilation = (
-                record.release_artist in COMPILATION_ARTISTS
-                or record.sort_artist == "Compilation"
-            )
+            # Use persisted compilation flag if available, otherwise detect
+            if record.persisted_is_compilation is not None:
+                record.is_compilation = record.persisted_is_compilation
+            else:
+                record.is_compilation = (
+                    record.release_artist in COMPILATION_ARTISTS
+                    or record.sort_artist == "Compilation"
+                )
             used_persisted = True
             logger.debug(
                 "Using persisted sort_artist for '%s': '%s'",

--- a/vinyl_sorter/persistence.py
+++ b/vinyl_sorter/persistence.py
@@ -1,0 +1,95 @@
+"""Write computed sort data back to Discogs custom fields."""
+
+import logging
+import time
+from typing import Dict, List, Optional
+
+from .discogs_api import DiscogsAPI
+from .models import VinylRecord
+
+logger = logging.getLogger(__name__)
+
+# Discogs rate limit: 60 requests/minute for authenticated users.
+# We add a small delay between writes to stay well within limits.
+WRITE_DELAY_SECONDS = 1.1
+
+
+def write_back_sort_data(
+    records: List[VinylRecord],
+    api: DiscogsAPI,
+    field_ids: Dict[str, Optional[int]],
+) -> int:
+    """Write computed sort data back to Discogs custom fields.
+
+    Only writes values that have changed (or were newly computed).
+    Skips records that already have matching persisted values.
+
+    Args:
+        records: List of parsed VinylRecord objects.
+        api: Authenticated Discogs API session.
+        field_ids: Mapping of logical name → Discogs field_id.
+
+    Returns:
+        Number of field writes performed.
+    """
+    artist_fid = field_ids.get("sort_artist")
+    year_fid = field_ids.get("sort_year")
+    month_fid = field_ids.get("sort_month")
+
+    if not any([artist_fid, year_fid, month_fid]):
+        logger.warning(
+            "No custom field IDs configured. Skipping write-back. "
+            "Create 'Sort Artist', 'Sort Year', and 'Sort Month' fields "
+            "in your Discogs collection settings."
+        )
+        return 0
+
+    write_count = 0
+    skip_count = 0
+
+    for record in records:
+        if record.instance_id == -1:
+            logger.warning("No instance_id for %s; skipping write-back.", record)
+            continue
+
+        writes_needed = []
+
+        # Check if sort_artist needs writing
+        if artist_fid and record.sort_artist != record.persisted_sort_artist:
+            writes_needed.append((artist_fid, str(record.sort_artist)))
+
+        # Check if sort_year needs writing
+        if year_fid and record.sort_year != record.persisted_sort_year:
+            writes_needed.append((year_fid, str(record.sort_year)))
+
+        # Check if sort_month needs writing
+        current_month = record.sort_month if record.sort_month else 0
+        persisted_month = record.persisted_sort_month if record.persisted_sort_month else 0
+        if month_fid and current_month != persisted_month:
+            writes_needed.append((month_fid, str(current_month)))
+
+        if not writes_needed:
+            skip_count += 1
+            continue
+
+        for fid, value in writes_needed:
+            time.sleep(WRITE_DELAY_SECONDS)
+            success = api.write_custom_field(
+                folder_id=record.folder_id,
+                release_id=record.discogs_id,
+                instance_id=record.instance_id,
+                field_id=fid,
+                value=value,
+            )
+            if success:
+                write_count += 1
+            else:
+                logger.warning(
+                    "Failed to write field %d for %s", fid, record
+                )
+
+    logger.info(
+        "Write-back complete: %d writes performed, %d records unchanged.",
+        write_count, skip_count,
+    )
+    return write_count

--- a/vinyl_sorter/persistence.py
+++ b/vinyl_sorter/persistence.py
@@ -35,12 +35,13 @@ def write_back_sort_data(
     artist_fid = field_ids.get("sort_artist")
     year_fid = field_ids.get("sort_year")
     month_fid = field_ids.get("sort_month")
+    comp_fid = field_ids.get("is_compilation")
 
-    if not any([artist_fid, year_fid, month_fid]):
+    if not any([artist_fid, year_fid, month_fid, comp_fid]):
         logger.warning(
             "No custom field IDs configured. Skipping write-back. "
-            "Create 'Sort Artist', 'Sort Year', and 'Sort Month' fields "
-            "in your Discogs collection settings."
+            "Create 'Sort Artist', 'Sort Year', 'Sort Month', and "
+            "'Is Compilation' fields in your Discogs collection settings."
         )
         return 0
 
@@ -67,6 +68,10 @@ def write_back_sort_data(
         persisted_month = record.persisted_sort_month if record.persisted_sort_month else 0
         if month_fid and current_month != persisted_month:
             writes_needed.append((month_fid, str(current_month)))
+
+        # Check if is_compilation needs writing
+        if comp_fid and record.is_compilation != record.persisted_is_compilation:
+            writes_needed.append((comp_fid, "Yes" if record.is_compilation else ""))
 
         if not writes_needed:
             skip_count += 1

--- a/vinyl_sorter/sorter.py
+++ b/vinyl_sorter/sorter.py
@@ -21,11 +21,15 @@ def sort_collection(records: List[VinylRecord]) -> List[VinylRecord]:
     """
     logger.info("Sorting collection by parsed fields…")
 
-    # is_compilation=False (0) sorts before True (1), so compilations land at the end
-    sorted_records = sorted(
-        records,
-        key=operator.attrgetter("is_compilation", "sort_artist", "sort_year", "sort_month"),
-    )
+    # is_compilation=False (0) sorts before True (1), so compilations land at the end.
+    # Non-compilations sort by artist → year → month.
+    # Compilations sort alphabetically by album title instead of date.
+    def _sort_key(record: VinylRecord) -> tuple:
+        if record.is_compilation:
+            return (1, record.release_title.lower(), 0, 0)
+        return (0, record.sort_artist, record.sort_year, record.sort_month)
+
+    sorted_records = sorted(records, key=_sort_key)
 
     for i, record in enumerate(sorted_records, start=1):
         record.sort_sequence = i

--- a/vinyl_sorter/sorter.py
+++ b/vinyl_sorter/sorter.py
@@ -1,4 +1,4 @@
-"""Sort the parsed collection by artist then by year."""
+"""Sort the parsed collection by artist then by date."""
 
 import logging
 import operator
@@ -10,10 +10,11 @@ logger = logging.getLogger(__name__)
 
 
 def sort_collection(records: List[VinylRecord]) -> List[VinylRecord]:
-    """Sort records alphabetically by sort_artist, then chronologically by sort_year.
+    """Sort records: compilations last, then alphabetically by sort_artist,
+    then chronologically by sort_year and sort_month.
 
     Args:
-        records: Parsed records with sort_artist and sort_year populated.
+        records: Parsed records with sort fields populated.
 
     Returns:
         New list of records in sorted order.
@@ -22,7 +23,8 @@ def sort_collection(records: List[VinylRecord]) -> List[VinylRecord]:
 
     # is_compilation=False (0) sorts before True (1), so compilations land at the end
     sorted_records = sorted(
-        records, key=operator.attrgetter("is_compilation", "sort_artist", "sort_year")
+        records,
+        key=operator.attrgetter("is_compilation", "sort_artist", "sort_year", "sort_month"),
     )
 
     for i, record in enumerate(sorted_records, start=1):

--- a/vinyl_sorter/sorter.py
+++ b/vinyl_sorter/sorter.py
@@ -2,11 +2,24 @@
 
 import logging
 import operator
+import re
 from typing import List
 
+from .constants import INSIGNIFICANT_LEADING_WORDS
 from .models import VinylRecord
 
 logger = logging.getLogger(__name__)
+
+# Pre-compile pattern for stripping leading insignificant words from titles
+_LEADING_WORD_RE = re.compile(
+    rf"^(?:{'|'.join(re.escape(w) for w in INSIGNIFICANT_LEADING_WORDS)})\b\s*",
+    re.IGNORECASE,
+)
+
+
+def _sort_title(title: str) -> str:
+    """Strip leading insignificant words (The, A, An) for sort purposes."""
+    return _LEADING_WORD_RE.sub("", title).lower()
 
 
 def sort_collection(records: List[VinylRecord]) -> List[VinylRecord]:
@@ -23,10 +36,11 @@ def sort_collection(records: List[VinylRecord]) -> List[VinylRecord]:
 
     # is_compilation=False (0) sorts before True (1), so compilations land at the end.
     # Non-compilations sort by artist → year → month.
-    # Compilations sort alphabetically by album title instead of date.
+    # Compilations sort alphabetically by album title (stripped of leading
+    # "The"/"A"/"An", same rule as group artist names).
     def _sort_key(record: VinylRecord) -> tuple:
         if record.is_compilation:
-            return (1, record.release_title.lower(), 0, 0)
+            return (1, _sort_title(record.release_title), 0, 0)
         return (0, record.sort_artist, record.sort_year, record.sort_month)
 
     sorted_records = sorted(records, key=_sort_key)


### PR DESCRIPTION
## Overview
Implements persistence of computed sort data back to Discogs, dramatically reducing run time on subsequent sorts. Builds on top of PR #9 (bugs #6, #7, #8).

## Setup Required
Create 3 **textarea** custom fields in your Discogs collection settings ([link](https://www.discogs.com/settings/collection)):
- **Sort Artist**
- **Sort Year**  
- **Sort Month**

The program auto-detects them by name. If they don't exist, it still works — just without persistence.

## How It Works

### First Run
- Full computation as before (~530 API calls for 300 records)
- Writes computed values back to Discogs (~900 write calls, rate-limited)
- One-time cost: ~24 minutes

### Subsequent Runs
- Reads persisted values on load (included in collection fetch — no extra calls)
- Skips all API lookups for records that have persisted data
- **~6 API calls instead of ~530 → 6 seconds instead of 9 minutes**

### New Records
- Records without persisted data get computed normally
- Only new records hit the API
- 5 new records in a 300-record collection: ~36 seconds

## New CLI Flags
- `--force-reparse` — Ignore persisted values, recompute everything
- `--no-write-back` — Compute but don't save to Discogs (dry run)
- `--field-sort-artist` / `--field-sort-year` / `--field-sort-month` — Customize field names if yours differ

## Files Changed
- **`persistence.py`** — New module: write-back logic with rate limiting
- **`loader.py`** — Reads instance_id, folder_id, and custom field values on load
- **`parser.py`** — Skips API lookups when persisted values exist
- **`models.py`** — New fields: instance_id, folder_id, persisted_sort_*
- **`discogs_api.py`** — Custom field read/write methods
- **`cli.py`** / **`config.py`** — New persistence options
- **`__main__.py`** — Wired up the full persistence pipeline
- **`docs/discogs-custom-fields-research.md`** — Research document

## Dependencies
- Requires PR #9 to be merged first (bugs #6, #7, #8)

Addresses #5