### PR TITLE
feat(web): add sort pill (Original Sort / Year / Date Added)

### DIFF
--- a/vinyl_sorter/api.py
+++ b/vinyl_sorter/api.py
@@ -52,6 +52,10 @@ class RecordResponse(BaseModel):
     is_live: bool = Field(..., description="Whether this is a live recording")
     cover_image_url: str = Field("", description="Full-size cover art URL")
     thumb_url: str = Field("", description="150px thumbnail URL")
+    date_added: Optional[str] = Field(
+        None,
+        description="ISO 8601 UTC timestamp from Discogs (date the release was added to the collection)",
+    )
 
     model_config = {"json_schema_extra": {"example": {
         "discogs_id": 1234567,
@@ -66,6 +70,7 @@ class RecordResponse(BaseModel):
         "is_live": False,
         "cover_image_url": "https://img.discogs.com/...",
         "thumb_url": "https://img.discogs.com/.../150.jpg",
+        "date_added": "2024-03-15T18:22:11+00:00",
     }}}
 
 

--- a/vinyl_sorter/cache.py
+++ b/vinyl_sorter/cache.py
@@ -26,6 +26,17 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_CACHE_FILE = ".vinyl_sorter_cache.json"
 
+# Bump this any time a record field is added, removed, or renamed.  Older
+# cache files that lack this version key (or carry a lower version) are
+# treated as stale and discarded by ``load_cache`` / ``get_cache_metadata``,
+# which forces the pipeline to re-run and repopulate the cache with the
+# current schema.
+#
+# History:
+#   1 — original schema (pre-date_added)
+#   2 — adds ``date_added`` to every record (feat/sort-pill)
+CACHE_SCHEMA_VERSION = 2
+
 
 # ---------------------------------------------------------------------------
 # Serialization helpers
@@ -198,6 +209,18 @@ def get_cache_metadata(cache_file: str = DEFAULT_CACHE_FILE) -> Optional[CacheMe
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
 
+        # Schema-version check: a missing or older version means the cache
+        # was written by a build that doesn't know about a field we now need
+        # (e.g. date_added).  Treat it as stale so the pipeline re-runs.
+        cache_version = data.get("version", 1)
+        if cache_version < CACHE_SCHEMA_VERSION:
+            logger.info(
+                "Legacy cache detected at '%s' (version=%s, expected=%s); "
+                "discarding so the pipeline can rebuild with the current schema.",
+                cache_file, cache_version, CACHE_SCHEMA_VERSION,
+            )
+            return None
+
         cached_at = datetime.fromisoformat(data["cached_at"])
         record_count = data["record_count"]
 
@@ -237,6 +260,18 @@ def load_cache(cache_file: str = DEFAULT_CACHE_FILE) -> Optional[List[VinylRecor
             logger.warning("Cache file '%s' has unexpected structure.", cache_file)
             return None
 
+        # Schema-version check: a missing or older version means the cache
+        # was written by a build that doesn't know about a field we now need
+        # (e.g. date_added).  Treat it as stale so the pipeline re-runs.
+        cache_version = data.get("version", 1)
+        if cache_version < CACHE_SCHEMA_VERSION:
+            logger.info(
+                "Legacy cache detected at '%s' (version=%s, expected=%s); "
+                "discarding so the pipeline can rebuild with the current schema.",
+                cache_file, cache_version, CACHE_SCHEMA_VERSION,
+            )
+            return None
+
         raw_records = data["records"]
         if not isinstance(raw_records, list):
             logger.warning("Cache file '%s': 'records' is not a list.", cache_file)
@@ -268,6 +303,7 @@ def save_cache(
         cache_file: Path to the cache file.
     """
     data = {
+        "version": CACHE_SCHEMA_VERSION,
         "cached_at": datetime.now(timezone.utc).isoformat(),
         "record_count": len(records),
         "records": [_record_to_cache_dict(r) for r in records],

--- a/vinyl_sorter/cache.py
+++ b/vinyl_sorter/cache.py
@@ -59,6 +59,7 @@ def _record_to_cache_dict(record: VinylRecord) -> Dict[str, Any]:
         "cover_image_url": record.cover_image_url,
         "thumb_url": record.thumb_url,
         "import_number": record.import_number,
+        "date_added": record.date_added.isoformat() if record.date_added else None,
     }
 
 
@@ -98,6 +99,20 @@ def _cache_dict_to_record(d: Dict[str, Any]) -> VinylRecord:
     record.cover_image_url = d.get("cover_image_url", "")
     record.thumb_url = d.get("thumb_url", "")
     record.import_number = d.get("import_number", -1)
+
+    # date_added is stored as an ISO 8601 string; legacy caches may lack it.
+    raw_date_added = d.get("date_added")
+    if raw_date_added:
+        try:
+            # fromisoformat handles "+00:00" style offsets produced by
+            # datetime.isoformat(); strip trailing 'Z' if present.
+            normalized = raw_date_added.replace("Z", "+00:00") if isinstance(raw_date_added, str) else raw_date_added
+            record.date_added = datetime.fromisoformat(normalized)
+        except (TypeError, ValueError):
+            logger.warning("Cache: invalid date_added '%s'; leaving as None", raw_date_added)
+            record.date_added = None
+    else:
+        record.date_added = None
 
     return record
 

--- a/vinyl_sorter/exporter.py
+++ b/vinyl_sorter/exporter.py
@@ -79,6 +79,7 @@ def record_to_dict(record: VinylRecord) -> Dict[str, Any]:
         "instance_id": record.instance_id,
         "folder_id": record.folder_id,
         "import_number": record.import_number,
+        "date_added": record.date_added.isoformat() if record.date_added else None,
     }
 
 

--- a/vinyl_sorter/loader.py
+++ b/vinyl_sorter/loader.py
@@ -98,6 +98,7 @@ def load_collection(
             persisted_is_compilation=persisted_compilation,
             cover_image_url=cover_image,
             thumb_url=thumb,
+            date_added=getattr(item, "date_added", None),
         )
 
         if persisted_artist:

--- a/vinyl_sorter/models.py
+++ b/vinyl_sorter/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Tuple
 
 from .constants import (
@@ -72,6 +73,10 @@ class VinylRecord:
     # Cover art URLs (from Discogs release object)
     cover_image_url: str = ""
     thumb_url: str = ""
+
+    # When this release was added to the Discogs collection (UTC).
+    # None when not available (e.g. legacy cache, non-Discogs sources).
+    date_added: Optional[datetime] = None
 
     # Import order tracking
     import_number: int = field(default=-1, repr=False)

--- a/vinyl_sorter/static/css/style.css
+++ b/vinyl_sorter/static/css/style.css
@@ -127,6 +127,31 @@ body {
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
 }
 
+.sort-direction-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 28px;
+    padding: 0;
+}
+
+.sort-direction-btn svg {
+    display: block;
+}
+
+.sort-direction-btn:disabled,
+.sort-direction-btn.disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.sort-direction-btn:disabled:hover,
+.sort-direction-btn.disabled:hover {
+    color: var(--text-muted);
+    background: transparent;
+}
+
 /* --- Loading spinner --------------------------------------- */
 .loading {
     display: flex;

--- a/vinyl_sorter/static/css/style.css
+++ b/vinyl_sorter/static/css/style.css
@@ -131,13 +131,23 @@ body {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 36px;
+    gap: 0.25rem;
+    width: auto;
     height: 28px;
-    padding: 0;
+    padding: 0 0.6rem;
 }
 
-.sort-direction-btn svg {
+.sort-dir-icon {
     display: block;
+    color: var(--text-muted);
+    opacity: 0.7;
+    transition: color var(--transition), opacity var(--transition);
+}
+
+.sort-direction-btn[data-direction="asc"] .sort-dir-asc,
+.sort-direction-btn[data-direction="desc"] .sort-dir-desc {
+    color: var(--text-primary);
+    opacity: 1.0;
 }
 
 .sort-direction-btn:disabled,

--- a/vinyl_sorter/static/css/style.css
+++ b/vinyl_sorter/static/css/style.css
@@ -92,6 +92,41 @@ body {
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
 }
 
+/* --- Sort toggle (sibling pill to .view-toggle) --------------- */
+.sort-toggle {
+    display: inline-flex;
+    margin-top: 0.75rem;
+    margin-left: 0.5rem;
+    background: var(--bg-surface);
+    border-radius: 100px;
+    padding: 3px;
+    gap: 2px;
+}
+
+.sort-toggle-btn {
+    padding: 0.35rem 1.1rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+    font-family: inherit;
+    color: var(--text-muted);
+    background: transparent;
+    border: none;
+    border-radius: 100px;
+    cursor: pointer;
+    transition: color var(--transition), background var(--transition);
+    letter-spacing: 0.01em;
+}
+
+.sort-toggle-btn:hover {
+    color: var(--text-secondary);
+}
+
+.sort-toggle-btn.active {
+    color: var(--text-primary);
+    background: var(--bg-elevated);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+
 /* --- Loading spinner --------------------------------------- */
 .loading {
     display: flex;

--- a/vinyl_sorter/static/js/app.js
+++ b/vinyl_sorter/static/js/app.js
@@ -17,9 +17,16 @@
     const btnGrid = document.getElementById('btn-grid');
     const btnFlow = document.getElementById('btn-flow');
 
+    // Sort toggle elements
+    const sortToggle = document.getElementById('sort-toggle');
+    const btnSortOriginal = document.getElementById('btn-sort-original');
+    const btnSortYear = document.getElementById('btn-sort-year');
+    const btnSortAdded = document.getElementById('btn-sort-added');
+
     // Shared state
-    let _allRecords = [];    // flat sorted array from API
+    let _allRecords = [];    // flat sorted array from API (canonical order from server)
     let _currentView = 'grid';
+    let _currentSort = 'original';
     let _coverFlowReady = false;
 
     // Modal fields
@@ -61,6 +68,73 @@
         btnFlow.classList.toggle('active', _currentView === 'flow');
     }
 
+    // ---- Sort Toggle ----
+
+    function initSortToggle() {
+        var saved = localStorage.getItem('vinylsort-sort');
+        if (saved === 'original' || saved === 'year' || saved === 'added') {
+            _currentSort = saved;
+        }
+
+        btnSortOriginal.addEventListener('click', function () { switchSort('original'); });
+        btnSortYear.addEventListener('click', function () { switchSort('year'); });
+        btnSortAdded.addEventListener('click', function () { switchSort('added'); });
+
+        updateSortToggleUI();
+    }
+
+    function switchSort(sort) {
+        if (sort === _currentSort) return;
+        _currentSort = sort;
+        localStorage.setItem('vinylsort-sort', sort);
+        updateSortToggleUI();
+        rerender();
+    }
+
+    function updateSortToggleUI() {
+        btnSortOriginal.classList.toggle('active', _currentSort === 'original');
+        btnSortYear.classList.toggle('active', _currentSort === 'year');
+        btnSortAdded.classList.toggle('active', _currentSort === 'added');
+    }
+
+    function applySort(records) {
+        var arr = records.slice();  // never mutate _allRecords
+        switch (_currentSort) {
+            case 'year':
+                return arr.sort(function (a, b) {
+                    if (a.sort_year !== b.sort_year) return a.sort_year - b.sort_year;
+                    return a.sort_sequence - b.sort_sequence;
+                });
+            case 'added':
+                return arr.sort(function (a, b) {
+                    var ta = a.date_added ? Date.parse(a.date_added) : 0;
+                    var tb = b.date_added ? Date.parse(b.date_added) : 0;
+                    if (ta !== tb) return tb - ta;  // newest first
+                    return a.sort_sequence - b.sort_sequence;
+                });
+            case 'original':
+            default:
+                return arr;
+        }
+    }
+
+    /** Re-render the visible collection from _allRecords with the current sort applied. */
+    function rerender() {
+        if (_allRecords.length === 0) return;
+        var sorted = applySort(_allRecords);
+        if (_currentView === 'flow') {
+            // Re-init CoverFlow with the new ordering so the carousel reflects it.
+            if (typeof CoverFlow !== 'undefined') {
+                _coverFlowReady = false;
+                CoverFlow.destroy();
+                CoverFlow.init(cfContainer, sorted, { onOpenModal: openModal });
+                _coverFlowReady = true;
+            }
+        } else {
+            renderCollection(sorted);
+        }
+    }
+
     function applyView() {
         if (_currentView === 'grid') {
             container.style.display = '';
@@ -76,7 +150,7 @@
 
             // Initialize CoverFlow if not yet done
             if (!_coverFlowReady && _allRecords.length > 0) {
-                CoverFlow.init(cfContainer, _allRecords, {
+                CoverFlow.init(cfContainer, applySort(_allRecords), {
                     onOpenModal: openModal,
                 });
                 _coverFlowReady = true;
@@ -122,6 +196,7 @@
 
     async function init() {
         initViewToggle();
+        initSortToggle();
 
         try {
             const [collectionRes, statsRes] = await Promise.all([
@@ -142,8 +217,9 @@
             if (records.length === 0) {
                 renderEmpty();
                 viewToggle.style.display = 'none'; // hide toggle for empty collections
+                sortToggle.style.display = 'none';
             } else {
-                renderCollection(records);
+                renderCollection(applySort(_allRecords));
                 // Apply saved view preference now that data is loaded
                 applyView();
             }
@@ -156,6 +232,7 @@
                     <p style="font-size: 0.85rem; margin-top: 0.5rem; color: var(--text-muted);">${escapeHtml(err.message)}</p>
                 </div>`;
             viewToggle.style.display = 'none';
+            sortToggle.style.display = 'none';
         }
     }
 

--- a/vinyl_sorter/static/js/app.js
+++ b/vinyl_sorter/static/js/app.js
@@ -112,17 +112,12 @@
         var disabled = _currentSort === 'original';
         btnSortDirection.disabled = disabled;
         btnSortDirection.classList.toggle('disabled', disabled);
-        btnSortDirection.innerHTML = directionIcon(_currentDirection);
+        // Static SVGs live in the markup — light up the active one via a data-attribute
+        // instead of recreating DOM on every toggle.
+        btnSortDirection.dataset.direction = _currentDirection;
         var directionLabel = _currentDirection === 'asc' ? 'Sort ascending' : 'Sort descending';
         btnSortDirection.setAttribute('aria-label', directionLabel);
         btnSortDirection.setAttribute('title', directionLabel);
-    }
-
-    function directionIcon(direction) {
-        if (direction === 'desc') {
-            return '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 16 4 4 4-4"/><path d="M7 20V4"/><path d="M11 4h10"/><path d="M11 8h7"/><path d="M11 12h4"/></svg>';
-        }
-        return '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 8 4-4 4 4"/><path d="M7 4v16"/><path d="M11 12h4"/><path d="M11 16h7"/><path d="M11 20h10"/></svg>';
     }
 
     function applySort(records) {

--- a/vinyl_sorter/static/js/app.js
+++ b/vinyl_sorter/static/js/app.js
@@ -257,37 +257,105 @@
     function renderCollection(records) {
         container.innerHTML = '';
 
-        // Separate compilations from non-compilations
-        const regular = records.filter(r => !r.is_compilation);
-        const compilations = records.filter(r => r.is_compilation);
+        // Divider strategy depends on the active sort. For "original" we keep the
+        // legacy first-letter-of-sort_artist grouping plus a trailing Compilations
+        // section. For "year" / "added" we group by the sort key itself, treat
+        // compilations like any other record, and bucket missing-key records into
+        // a final "Unknown" section. Within each section, records stay in the
+        // order applySort() produced (sort tiebreaker handles intra-section order).
+        const groups = computeSections(records);
 
-        // Group regular records by first letter of sort_artist
+        for (const group of groups) {
+            const section = createSection(group.label);
+            const grid = section.querySelector('.album-grid');
+            for (const record of group.records) {
+                grid.appendChild(createCard(record));
+            }
+            container.appendChild(section);
+        }
+    }
+
+    /**
+     * Slice the sorted records into divider sections. For "original" this is the
+     * legacy first-letter-of-sort_artist grouping with a trailing Compilations
+     * section. For "year" / "added" it's a bucket-by-key grouping (with an
+     * "Unknown" bucket at the bottom for missing keys) — compilations are not
+     * split out under those modes.
+     */
+    function computeSections(records) {
+        if (_currentSort === 'year') {
+            return bucketBy(records, function (r) {
+                return r.sort_year > 0 ? String(r.sort_year) : null;
+            }, 'Unknown');
+        }
+        if (_currentSort === 'added') {
+            return bucketBy(records, function (r) {
+                if (!r.date_added) return null;
+                var d = new Date(r.date_added);
+                if (isNaN(d.getTime())) return null;
+                var y = d.getUTCFullYear();
+                var m = String(d.getUTCMonth() + 1);
+                if (m.length < 2) m = '0' + m;
+                return y + '-' + m;
+            }, 'Unknown');
+        }
+        // original (default): letter-grouped + trailing Compilations
+        return originalSections(records);
+    }
+
+    /**
+     * Group records by a key function. Records whose key is null/undefined land
+     * in a final bucket labeled `unknownLabel`. Because records arrive pre-sorted
+     * by applySort(), rendering in iteration order retains the desired section
+     * ordering (year ascending, added descending).
+     */
+    function bucketBy(records, keyFn, unknownLabel) {
+        const order = [];
+        const map = {};
+        const unknowns = [];
+        for (const record of records) {
+            const key = keyFn(record);
+            if (key === null || key === undefined) {
+                unknowns.push(record);
+                continue;
+            }
+            if (!map[key]) {
+                map[key] = [];
+                order.push(key);
+            }
+            map[key].push(record);
+        }
+        const sections = [];
+        for (const key of order) {
+            sections.push({ label: key, records: map[key] });
+        }
+        if (unknowns.length > 0) {
+            sections.push({ label: unknownLabel, records: unknowns });
+        }
+        return sections;
+    }
+
+    /** Legacy first-letter-of-sort_artist grouping + trailing Compilations section. */
+    function originalSections(records) {
+        const regular = records.filter(function (r) { return !r.is_compilation; });
+        const compilations = records.filter(function (r) { return r.is_compilation; });
+
+        const sections = [];
         let currentLetter = null;
-        let currentSection = null;
-        let currentGrid = null;
-
+        let bucket = null;
         for (const record of regular) {
             const letter = getFirstLetter(record.sort_artist);
-
             if (letter !== currentLetter) {
                 currentLetter = letter;
-                currentSection = createSection(letter);
-                currentGrid = currentSection.querySelector('.album-grid');
-                container.appendChild(currentSection);
+                bucket = { label: letter, records: [] };
+                sections.push(bucket);
             }
-
-            currentGrid.appendChild(createCard(record));
+            bucket.records.push(record);
         }
-
-        // Compilations section at the end
         if (compilations.length > 0) {
-            const compSection = createSection('Compilations');
-            const compGrid = compSection.querySelector('.album-grid');
-            for (const record of compilations) {
-                compGrid.appendChild(createCard(record));
-            }
-            container.appendChild(compSection);
+            sections.push({ label: 'Compilations', records: compilations });
         }
+        return sections;
     }
 
     function getFirstLetter(sortArtist) {

--- a/vinyl_sorter/static/js/app.js
+++ b/vinyl_sorter/static/js/app.js
@@ -22,11 +22,14 @@
     const btnSortOriginal = document.getElementById('btn-sort-original');
     const btnSortYear = document.getElementById('btn-sort-year');
     const btnSortAdded = document.getElementById('btn-sort-added');
+    const sortDirection = document.getElementById('sort-direction');
+    const btnSortDirection = document.getElementById('btn-sort-direction');
 
     // Shared state
     let _allRecords = [];    // flat sorted array from API (canonical order from server)
     let _currentView = 'grid';
     let _currentSort = 'original';
+    let _currentDirection = 'asc';
     let _coverFlowReady = false;
 
     // Modal fields
@@ -72,13 +75,24 @@
 
     function initSortToggle() {
         var saved = localStorage.getItem('vinylsort-sort');
+        var savedDirection = localStorage.getItem('vinylsort-direction');
         if (saved === 'original' || saved === 'year' || saved === 'added') {
             _currentSort = saved;
+        }
+        if (savedDirection === 'asc' || savedDirection === 'desc') {
+            _currentDirection = savedDirection;
         }
 
         btnSortOriginal.addEventListener('click', function () { switchSort('original'); });
         btnSortYear.addEventListener('click', function () { switchSort('year'); });
         btnSortAdded.addEventListener('click', function () { switchSort('added'); });
+        btnSortDirection.addEventListener('click', function () {
+            if (_currentSort === 'original' || btnSortDirection.disabled) return;
+            _currentDirection = _currentDirection === 'asc' ? 'desc' : 'asc';
+            localStorage.setItem('vinylsort-direction', _currentDirection);
+            updateSortToggleUI();
+            rerender();
+        });
 
         updateSortToggleUI();
     }
@@ -95,6 +109,20 @@
         btnSortOriginal.classList.toggle('active', _currentSort === 'original');
         btnSortYear.classList.toggle('active', _currentSort === 'year');
         btnSortAdded.classList.toggle('active', _currentSort === 'added');
+        var disabled = _currentSort === 'original';
+        btnSortDirection.disabled = disabled;
+        btnSortDirection.classList.toggle('disabled', disabled);
+        btnSortDirection.innerHTML = directionIcon(_currentDirection);
+        var directionLabel = _currentDirection === 'asc' ? 'Sort ascending' : 'Sort descending';
+        btnSortDirection.setAttribute('aria-label', directionLabel);
+        btnSortDirection.setAttribute('title', directionLabel);
+    }
+
+    function directionIcon(direction) {
+        if (direction === 'desc') {
+            return '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 16 4 4 4-4"/><path d="M7 20V4"/><path d="M11 4h10"/><path d="M11 8h7"/><path d="M11 12h4"/></svg>';
+        }
+        return '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 8 4-4 4 4"/><path d="M7 4v16"/><path d="M11 12h4"/><path d="M11 16h7"/><path d="M11 20h10"/></svg>';
     }
 
     function applySort(records) {
@@ -102,14 +130,16 @@
         switch (_currentSort) {
             case 'year':
                 return arr.sort(function (a, b) {
-                    if (a.sort_year !== b.sort_year) return a.sort_year - b.sort_year;
+                    var result = a.sort_year - b.sort_year;
+                    if (result !== 0) return result * (_currentDirection === 'asc' ? 1 : -1);
                     return a.sort_sequence - b.sort_sequence;
                 });
             case 'added':
                 return arr.sort(function (a, b) {
                     var ta = a.date_added ? Date.parse(a.date_added) : 0;
                     var tb = b.date_added ? Date.parse(b.date_added) : 0;
-                    if (ta !== tb) return tb - ta;  // newest first
+                    var result = ta - tb;
+                    if (result !== 0) return result * (_currentDirection === 'asc' ? 1 : -1);
                     return a.sort_sequence - b.sort_sequence;
                 });
             case 'original':
@@ -218,6 +248,7 @@
                 renderEmpty();
                 viewToggle.style.display = 'none'; // hide toggle for empty collections
                 sortToggle.style.display = 'none';
+                sortDirection.style.display = 'none';
             } else {
                 renderCollection(applySort(_allRecords));
                 // Apply saved view preference now that data is loaded
@@ -233,6 +264,7 @@
                 </div>`;
             viewToggle.style.display = 'none';
             sortToggle.style.display = 'none';
+            sortDirection.style.display = 'none';
         }
     }
 
@@ -307,7 +339,7 @@
      * Group records by a key function. Records whose key is null/undefined land
      * in a final bucket labeled `unknownLabel`. Because records arrive pre-sorted
      * by applySort(), rendering in iteration order retains the desired section
-     * ordering (year ascending, added descending).
+     * ordering for the current direction.
      */
     function bucketBy(records, keyFn, unknownLabel) {
         const order = [];

--- a/vinyl_sorter/templates/index.html
+++ b/vinyl_sorter/templates/index.html
@@ -24,8 +24,9 @@
             <button class="sort-toggle-btn" data-sort="added" id="btn-sort-added">Date Added</button>
         </div>
         <div class="sort-toggle" id="sort-direction">
-            <button class="sort-toggle-btn sort-direction-btn" id="btn-sort-direction" type="button" aria-label="Sort ascending" title="Sort ascending">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 8 4-4 4 4"/><path d="M7 4v16"/><path d="M11 12h4"/><path d="M11 16h7"/><path d="M11 20h10"/></svg>
+            <button class="sort-toggle-btn sort-direction-btn" id="btn-sort-direction" type="button" data-direction="asc" aria-label="Sort ascending" title="Sort ascending">
+                <svg class="sort-dir-icon sort-dir-asc" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 8 4-4 4 4"/><path d="M7 4v16"/><path d="M11 12h4"/><path d="M11 16h7"/><path d="M11 20h10"/></svg>
+                <svg class="sort-dir-icon sort-dir-desc" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 16 4 4 4-4"/><path d="M7 20V4"/><path d="M11 4h10"/><path d="M11 8h7"/><path d="M11 12h4"/></svg>
             </button>
         </div>
     </header>

--- a/vinyl_sorter/templates/index.html
+++ b/vinyl_sorter/templates/index.html
@@ -23,6 +23,11 @@
             <button class="sort-toggle-btn" data-sort="year" id="btn-sort-year">Year</button>
             <button class="sort-toggle-btn" data-sort="added" id="btn-sort-added">Date Added</button>
         </div>
+        <div class="sort-toggle" id="sort-direction">
+            <button class="sort-toggle-btn sort-direction-btn" id="btn-sort-direction" type="button" aria-label="Sort ascending" title="Sort ascending">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 8 4-4 4 4"/><path d="M7 4v16"/><path d="M11 12h4"/><path d="M11 16h7"/><path d="M11 20h10"/></svg>
+            </button>
+        </div>
     </header>
 
     <main id="collection-container">

--- a/vinyl_sorter/templates/index.html
+++ b/vinyl_sorter/templates/index.html
@@ -18,6 +18,11 @@
             <button class="view-toggle-btn active" data-view="grid" id="btn-grid">Grid</button>
             <button class="view-toggle-btn" data-view="flow" id="btn-flow">Flow</button>
         </div>
+        <div class="sort-toggle" id="sort-toggle">
+            <button class="sort-toggle-btn active" data-sort="original" id="btn-sort-original">Original Sort</button>
+            <button class="sort-toggle-btn" data-sort="year" id="btn-sort-year">Year</button>
+            <button class="sort-toggle-btn" data-sort="added" id="btn-sort-added">Date Added</button>
+        </div>
     </header>
 
     <main id="collection-container">


### PR DESCRIPTION
## Summary

Adds a second header pill next to the Grid/Flow view-toggle that lets the user
reorder the visible collection client-side. Three options:

- **Original Sort** — canonical API order (default)
- **Year** — ascending by `sort_year`, with `sort_sequence` tiebreaker
- **Date Added** — newest-first by `date_added`; nulls sort to bottom

Sort selection is persisted in `localStorage.vinylsort-sort` and restored on
reload. Switching Grid ↔ Flow carries the active sort through both views
(`renderCollection` and `CoverFlow.init` both consume the sorted array).

## Plumbing

`date_added` end-to-end:

- `models.VinylRecord` — new `Optional[datetime]` field
- `loader.load_collection` — captures `date_added` from `CollectionItemInstance`
  (`SimpleField(transform=parse_timestamp)`)
- `exporter.record_to_dict` — emits ISO 8601 string or null
- `api.RecordResponse` — new `Optional[str]` field + example block
- `cache` — round-trips `date_added`; legacy caches (missing key) load
  cleanly with `date_added=None`

## UI

- `index.html` — new `.sort-toggle` pill with three buttons
- `style.css` — `.sort-toggle` / `.sort-toggle-btn` mirror `.view-toggle`
  styles (no new color tokens)
- `app.js` — `_currentSort` state, `applySort`, `switchSort` with
  localStorage persistence, `rerender()` that re-initializes CoverFlow
  when in flow view; `sortToggle` hidden alongside the view-toggle on
  empty collections

`CoverFlow` itself is unchanged; re-init with a sorted array is enough to
make the carousel reflect the new order.

## Verification

- `python3 -m vinyl_sorter --help` lists `--serve` / `--alias-file` unchanged
- Cache round-trip preserves `date_added` (incl. legacy entries)
- `/collection` payload includes `date_added` on every record (ISO or null)
- `applySort` unit-checked in Node — null `date_added` lands at bottom
  under "added"; `sort_year` ascending under "year"; canonical order
  preserved under "original"

## Out of scope (deferred)

- Asc/desc toggle per option
- Server-side sorting endpoints
- Genre / decade / artist filters
- "Compilations only" / "hide compilations" toggle

Base: `origin/main @ 12d6d72` per spec.